### PR TITLE
Add rehypeVariables plugin to use variables in mdx

### DIFF
--- a/docs/android-sdk.mdx
+++ b/docs/android-sdk.mdx
@@ -40,7 +40,6 @@ scope.launch {
     println(it) // 'Connected' or 'Disconnected'
   }
 }
-
 ```
 By using the value of the `streamConnectionStatus`, it is possible to determine whether the Client is connected to the network.
 
@@ -73,13 +72,13 @@ After attaching the Document to the Client, all changes to the Document are auto
 scope.launch {
   val message = "update document for test"
   document.updateAsync(message) { root ->
-    root.setNewObject("obj") // {"obj":{}}
-    root.getAs<JsonObject>("obj")["num"] = 1 // {"obj":{"num":1}}
+    root.setNewObject("obj")                                       // {"obj":{}}
+    root.getAs<JsonObject>("obj")["num"] = 1                       // {"obj":{"num":1}}
     root.getAs<JsonObject>("obj").setNewObject("obj")["str"] = "a" // {"obj":{"num":1,"obj":{"str":"a"}}}
-    root.getAs<JsonObject>("obj").setNewArray("arr").apply {
+    root.getAs<JsonObject>("obj").setNewArray("arr").apply {       // {"obj":{"num":1,"obj":{"str":"a"},"arr":[1,2]}}
       put(1)
       put(2)
-    } // {"obj":{"num":1,"obj":{"str":"a"},"arr":[1,2]}}
+    } 
   }.await()
 }
 ```
@@ -90,7 +89,7 @@ You can get the contents of the Document using `document.getRoot()`.
 
 ```kotlin
 val root = document.getRoot()
-println(root["obj"]) // {"num":1,"obj":{"str":"a"},"arr":[1,2]}
+println(root["obj"])                          // {"num":1,"obj":{"str":"a"},"arr":[1,2]}
 println(root.getAs<JsonObject>("obj")["num"]) // 1
 println(root.getAs<JsonObject>("obj")["obj"]) // {"str":"a"}
 println(root.getAs<JsonObject>("obj")["arr"]) // [1,2]
@@ -144,9 +143,9 @@ Custom CRDT types are data types that can be used for special applications such 
 // Declare your own CoroutineScope
 scope.launch {
   target.updateAsync("") { root ->
-    root.setNewCounter("counter", 1) // {"counter":1}
-    root.getAs<JsonCounter>("counter").increase(3) // {"counter":4}
-    root.getAs<JsonCounter>("counter").increase(6L) // {"counter":10}
+    root.setNewCounter("counter", 1)                // {"counter":1}
+    root.getAs<JsonCounter>("counter").increase(3)  // {"counter":4}
+    root.getAs<JsonCounter>("counter").increase(6)  // {"counter":10}
     root.getAs<JsonCounter>("counter").increase(-3) // {"counter":7}
   }.await()
 }

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -22,7 +22,7 @@ The easiest way to install Yorkie is from pre-built binaries:
 
 ```bash
 $ yorkie version
-Yorkie: {{site.version}}
+Yorkie: {{SITE_VERSION}}
 Commit: ...
 Go: ...
 Build date: ...
@@ -48,7 +48,7 @@ Verify that the installation worked by opening a new Terminal session and trying
 
 ```bash
 $ yorkie version
-Yorkie: {{site.version}}
+Yorkie: {{SITE_VERSION}}
 Commit: ...
 Go: ...
 Build date: ...
@@ -149,7 +149,7 @@ $ yorkie project create test-project
 If you create a Client with `public_key` of the Project as `apiKey`, you can manage the Client in the Project.
 
 ```javascript
-const client = new yorkie.Client('localhost:8080', {
+const client = new yorkie.Client('{{API_ADDR}}', {
   apiKey: 'c9u9298qp9as73b8i190', // public_key of the project
 });
 ```
@@ -205,7 +205,7 @@ This page shows how to set up an Auth Webhook. The overall flow is as follows:
 First, We need to pass some tokens (that identify users in the service) when creating a Client:
 
 ```javascript
-const client = new yorkie.Client('localhost:8080', {
+const client = new yorkie.Client('{{API_ADDR}}', {
   token: SOME_TOKEN,
 });
 ```

--- a/docs/getting-started/with-js-sdk.mdx
+++ b/docs/getting-started/with-js-sdk.mdx
@@ -19,7 +19,7 @@ or just include the following code in the `<head>` tag of your HTML:
 
 ```html
 <!-- include yorkie js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/yorkie-js-sdk/{{site.version}}/yorkie-js-sdk.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/yorkie-js-sdk/{{SITE_VERSION}}/yorkie-js-sdk.js"></script>
 ```
 
 > The JS SDKs are also provided by [cdnjs](https://cdnjs.com) to make loading library files faster and easier on websites.<br/>For more the JS SDKs: [https://cdnjs.com/libraries/yorkie-js-sdk](https://cdnjs.com/libraries/yorkie-js-sdk)
@@ -33,7 +33,7 @@ First, create a Client and a Document.
 ```js
 async function main() {
   // 01. create a new client instance and connect to the yorkie server
-  const client = new yorkie.Client('http://localhost:8080');
+  const client = new yorkie.Client('{{API_ADDR}}');
   await client.activate();
 
   // 02. create a new document and attach it to the client

--- a/docs/ios-sdk.mdx
+++ b/docs/ios-sdk.mdx
@@ -63,11 +63,11 @@ After attaching the Document to the Client, all changes to the Document are auto
 ```swift
 let message = "update document for test";
 await doc.update({ root in
-  root.obj = [:] // {"obj":{}}
+  root.obj = [:]                      // {"obj":{}}
   let obj = root.obj as! JSONObject
-  obj.num = Int64(1) // {"obj":{"num":1}}
-  obj.obj = ["str": "a"] // {"obj":{"num":1,"obj":{"str":"a"}}}
-  obj.arr = [Int64(1), Int64(2)] // {"obj":{"num":1,"obj":{"str":"a"},"arr":[1,2]}}
+  obj.num = Int64(1)                  // {"obj":{"num":1}}
+  obj.obj = ["str": "a"]              // {"obj":{"num":1,"obj":{"str":"a"}}}
+  obj.arr = [Int64(1), Int64(2)]      // {"obj":{"num":1,"obj":{"str":"a"},"arr":[1,2]}}
 }, message: message);
 ```
 
@@ -79,9 +79,9 @@ You can get the contents of the Document using `doc.getRoot()`.
 let root = doc.getRoot()
 print(root.obj!) // {"num":1,"obj":{"str":"a"},"arr":[1,2]}
 let obj = root.obj as! JSONObject
-print(obj.num!) // 1
-print(obj.obj!) // {"str":"a"}
-print(obj.arr!) // [1,2]
+print(obj.num!)  // 1
+print(obj.obj!)  // {"str":"a"}
+print(obj.arr!)  // [1,2]
 ```
 
 #### Subscribing to Document events

--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -18,7 +18,7 @@ If you want to install the SDK, refer to the [Getting Started with JS SDK](/docs
 We can create a Client using `new yorkie.Client()`. After the Client has been activated, it is connected to the server and ready to use.
 
 ```javascript
-const client = new yorkie.Client('localhost:8080');
+const client = new yorkie.Client('{{API_ADDR}}');
 await client.activate();
 ```
 
@@ -55,7 +55,7 @@ Peer Awareness is a feature often required in collaborative applications. With P
 When creating a Client, we can pass information of the Client to other peers attaching the same Document with presence.
 
 ```javascript
-const clientA = new yorkie.Client('localhost:8080', {
+const clientA = new yorkie.Client('{{API_ADDR}}', {
   presence: {
     username: 'alice',
     color: 'blue',
@@ -70,7 +70,7 @@ await clientA.attach(docA);
 Then, another Client is created and attaches a Document with the same name as before.
 
 ```javascript
-const clientB = new yorkie.Client('localhost:8080', {
+const clientB = new yorkie.Client('{{API_ADDR}}', {
   presence: {
     username: 'bob',
     color: 'red',
@@ -120,10 +120,10 @@ After attaching the Document to the Client, all changes to the Document are auto
 ```javascript
 const message = 'update document for test';
 doc.update((root) => {
-  root.obj = {}; // {"obj":{}}
-  root.obj.num = 1; // {"obj":{"num":1}}
+  root.obj = {};               // {"obj":{}}
+  root.obj.num = 1;            // {"obj":{"num":1}}
   root.obj.obj = { str: 'a' }; // {"obj":{"num":1,"obj":{"str":"a"}}}
-  root.obj.arr = ['1', '2']; // {"obj":{"num":1,"obj":{"str":"a"},"arr":[1,2]}}
+  root.obj.arr = ['1', '2'];   // {"obj":{"num":1,"obj":{"str":"a"},"arr":[1,2]}}
 }, message);
 ```
 
@@ -133,7 +133,7 @@ You can get the contents of the Document using `document.getRoot()`.
 
 ```javascript
 const root = doc.getRoot();
-console.log(root.obj); // {"num":1,"obj":{"str":"a"},"arr":[1,2]}
+console.log(root.obj);     // {"num":1,"obj":{"str":"a"},"arr":[1,2]}
 console.log(root.obj.num); // 1
 console.log(root.obj.obj); // {"str":"a"}
 console.log(root.obj.arr); // [1,2]
@@ -183,8 +183,8 @@ Custom CRDT types are data types that can be used for special applications such 
 doc.update((root) => {
   root.text = new yorkie.Text(); // {"text":""}
   root.text.edit(0, 0, 'hello'); // {"text":"hello"}
-  root.text.edit(0, 1, 'H'); // {"text":"Hello"}
-  root.text.select(0, 1); // {"text":"^H^ello"}
+  root.text.edit(0, 1, 'H');     // {"text":"Hello"}
+  root.text.select(0, 1);        // {"text":"^H^ello"}
 });
 ```
 
@@ -196,9 +196,9 @@ An example of Text co-editing with CodeMirror: [CodeMirror example](https://gith
 
 ```javascript
 doc.update((root) => {
-  root.text = new yorkie.RichText(); // {"text":""}
-  root.text.edit(0, 0, 'hello'); // {"text":"hello"}
-  root.text.edit(0, 1, 'H'); // {"text":"Hello"}
+  root.text = new yorkie.RichText();        // {"text":""}
+  root.text.edit(0, 0, 'hello');            // {"text":"hello"}
+  root.text.edit(0, 1, 'H');                // {"text":"Hello"}
   root.text.setStyle(0, 1, { bold: true }); // {"text":"<b>H</b>ello"}
 });
 ```
@@ -212,9 +212,9 @@ An example of RichText co-editing with Quill: [Quill example](https://github.com
 ```javascript
 doc.update((root) => {
   root.counter = new yorkie.Counter(1); // {"counter":1}
-  root.counter.increase(2); // {"counter":3}
-  root.counter.increase(3.5); // {"counter":6.5}
-  root.counter.increase(-3.5); // {"counter":3}
+  root.counter.increase(2);             // {"counter":3}
+  root.counter.increase(3.5);           // {"counter":6.5}
+  root.counter.increase(-3.5);          // {"counter":3}
 });
 ```
 

--- a/docs/sample/sample-nested.mdx
+++ b/docs/sample/sample-nested.mdx
@@ -6,3 +6,32 @@ order: 81
 ## Docs-Sample-Nested
 
 Describe about this section breifly. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam dignissim sem enim, convallis auctor arcu volutpat bibendum. Mauris augue est, pulvinar et neque ut, cursus porttitor tortor. Integer placerat velit quis dignissim consequat. Sed pellentesque ullamcorper rhoncus. Maecenas in urna porttitor, fringilla est accumsan, pellentesque sem.
+
+```html
+<span>{{API_ADDR}}</span>
+```
+
+You can use variables in mdx using the `rehypeVariables` plugin. 
+For example, `{{API_ADDR}}` will be replaced with `process.env.NEXT_PUBLIC_API_ADDR` on this page.
+
+- use in codeblock: `{{API_ADDR}}`
+- You need to escape `{` in contents: \{\{API_ADDR\}\}
+
+To use variables, you should add the variables option in the `pages/docs`.
+
+```js
+// [[...slug]].tsx 
+rehypePlugins: [
+  ...,
+  [
+    rehypeVariables,
+    {
+      variables: [
+        { pattern: 'API_ADDR', value: process.env.NEXT_PUBLIC_API_ADDR },
+        { pattern: 'SITE_VERSION', value: '1.0' },
+      ],
+    },
+  ],
+  ...
+],
+```

--- a/docs/server.mdx
+++ b/docs/server.mdx
@@ -89,10 +89,10 @@ Then, the ports of the services are bound to the host environment.
 
 <Alert status="warning">Server stores its data using an in-memory DB, which does not provide durability. If you want to store data permanently, please refer to [Running Server With MongoDB](/docs/server#running-server-with-mongodb)</Alert>
 
-Now, let's create a Client with address `localhost:8080`.
+Now, let's create a Client with address `{{API_ADDR}}`.
 
 ```javascript
-const client = new yorkie.Client('localhost:8080');
+const client = new yorkie.Client('{{API_ADDR}}');
 await client.activate();
 ```
 

--- a/pages/docs/[[...slug]].tsx
+++ b/pages/docs/[[...slug]].tsx
@@ -11,6 +11,7 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeToc, { HtmlElementNode, ListItemNode } from '@jsdevtools/rehype-toc';
 import rehypeImageMeta from '@/utils/rehypeImageMeta';
 import rehypeWrapContents from '@/utils/rehypeWrapContents';
+import rehypeVariables from '@/utils/rehypeVariables';
 import { Layout, Navigator, Button, Icon, CodeBlock, CodeBlockHeader, Image } from '@/components';
 import { CustomLink, CustomCodeBlock, Breadcrumb, Caption, ImageWrap, Alert, Blockquote } from '@/components/docs';
 
@@ -120,6 +121,15 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       remarkPlugins: [remarkGfm],
       rehypePlugins: [
         rehypeImageMeta,
+        [
+          rehypeVariables,
+          {
+            variables: [
+              { pattern: 'API_ADDR', value: process.env.NEXT_PUBLIC_API_ADDR },
+              { pattern: 'SITE_VERSION', value: '1.0' },
+            ],
+          },
+        ],
         rehypeSlug,
         [
           rehypeAutolinkHeadings,

--- a/utils/rehypeVariables.ts
+++ b/utils/rehypeVariables.ts
@@ -1,0 +1,36 @@
+import { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+interface TextNode extends Node {
+  type: 'text';
+  value: string;
+}
+
+function isTextNode(node: Node): node is TextNode {
+  return node.type === 'text';
+}
+
+type VARIABLE_MAP = {
+  pattern: string;
+  value: string;
+};
+
+function replaceVariables(text: string, map: VARIABLE_MAP[]): string {
+  let result = text;
+  for (const { pattern, value } of map) {
+    result = result.replace(new RegExp(`{{${pattern}}}`, 'gi'), value);
+  }
+  return result;
+}
+
+export default function rehypeVariables(options: { variables: VARIABLE_MAP[] }) {
+  return async function transformer(tree: Node): Promise<Node> {
+    visit(tree, (node: Node) => {
+      if (isTextNode(node)) {
+        node.value = replaceVariables(node.value, options.variables);
+      }
+    });
+
+    return tree;
+  };
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

You can use variables in mdx using the `rehypeVariables` plugin. 
For example, `{{API_ADDR}}` will be replaced with `process.env.NEXT_PUBLIC_API_ADDR` on this page.

- use in codeblock: `{{API_ADDR}}`
- You need to escape `{` in contents:  `\{\{API_ADDR\}\}`

To use variables, you should add the variables option in the `pages/docs`.

```js
// [[...slug]].tsx 
rehypePlugins: [
  ...,
  [
    rehypeVariables,
    {
      variables: [
        { pattern: 'API_ADDR', value: process.env.NEXT_PUBLIC_API_ADDR },
        { pattern: 'SITE_VERSION', value: '1.0' },
      ],
    },
  ],
  ...
],
```

to-do
- [ ] Apply SITE_VERSION properly
- [ ] Apply API_ADDR in ios-sdk, android-sdk

#### Any background context you want to provide?

`next-mdx-remote` doesn't support `import` statements. https://github.com/hashicorp/next-mdx-remote/issues/143

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
