### PR TITLE
Add profile-stack example

### DIFF
--- a/components/BasicExample/BasicExampleView.tsx
+++ b/components/BasicExample/BasicExampleView.tsx
@@ -1,9 +1,7 @@
 import classNames from 'classnames';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import yorkie from 'yorkie-js-sdk';
-import { ProjectCodeType } from './types';
 import { Icon } from '../Icons/Icon';
-import { Sidebar } from './Sidebar';
 import UserContent from './UserContent';
 
 interface DocChangeInfo {
@@ -11,38 +9,23 @@ interface DocChangeInfo {
   content: string;
 }
 
-export const UserNames = {
-  user1: 'User 1',
-  user2: 'User 2',
-  user3: 'User 3',
-  user4: 'User 4',
-};
-export const UserColors = {
-  user1: 'green',
-  user2: 'purple',
-  user3: 'red',
-  user4: 'yellow',
-};
+export const UserColors = ['red', 'yellow', 'green', 'orange', 'blue', 'purple'];
 
 export function BasicExampleView({
   rpcAddr,
+  apiKey,
   documentKey,
-  projectCode,
   iframeURL,
-  documentStructure,
-  apiKey: apiKey,
-  codeURL,
+  userMaxCount = 4,
 }: {
   rpcAddr: string;
   apiKey: string;
   documentKey: string;
-  projectCode: ProjectCodeType;
-  documentStructure: string;
   iframeURL: string;
-  codeURL: string;
+  userMaxCount?: number;
 }) {
   const [docChangeInfos, setDocChangeInfos] = useState<DocChangeInfo[]>([]);
-  const [userList, setUserList] = useState<('user1' | 'user2' | 'user3' | 'user4')[]>(['user1', 'user2']);
+  const [userList, setUserList] = useState<number[]>([1, 2]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     let unsubscribeDoc: Function;
@@ -88,102 +71,84 @@ export function BasicExampleView({
   useEffect(scrollToBottom, [docChangeInfos, scrollToBottom]);
 
   const deleteUser = useCallback(
-    (userId: string) => {
+    (userId: number) => {
       if (userList.length === 1) {
         alert('You need at least one user');
         return;
       }
-      setUserList((prev) => prev.filter((user) => user !== userId));
+      setUserList((prev) => prev.filter((userNumber) => userNumber !== userId));
     },
     [setUserList, userList.length],
   );
 
   const addUser = useCallback(() => {
-    if (userList.length === 4) {
+    if (userList.length === userMaxCount) {
       alert("You can't add more users");
       return;
     }
-    if (userList[0] !== 'user1') {
-      setUserList((prev) => ['user1', ...prev]);
+    if (userList.length === userList[userList.length - 1]) {
+      setUserList((prev) => [...prev, userList.length + 1]);
       return;
     }
-    if (userList[1] !== 'user2') {
-      setUserList((prev) => prev.slice(0, 1).concat(['user2']).concat(prev.slice(1)));
-      return;
+    for (let i = 0; i < userList.length; i++) {
+      if (userList[i] !== i + 1) {
+        setUserList((prev) => [...prev.slice(0, i), i + 1, ...prev.slice(i)]);
+        return;
+      }
     }
-    if (userList[2] !== 'user3') {
-      setUserList((prev) => prev.slice(0, 2).concat(['user3']).concat(prev.slice(2)));
-      return;
-    }
-    if (userList[3] !== 'user4') {
-      setUserList((prev) => prev.slice(0, 3).concat(['user4']).concat(prev.slice(3)));
-      return;
-    }
-  }, [setUserList, userList]);
+  }, [setUserList, userList, userMaxCount]);
 
   return (
-    <main className="container">
-      <Sidebar
-        title="Kanban Board"
-        description="Kanban Board is a tool for managing tasks and workflow. It is a visual way to manage tasks and workflow."
-        codeURL={codeURL}
-        projectCode={projectCode}
-        documentStructure={documentStructure}
-        defaultOpened
-      />
-      <div className="content code_view">
-        <div className="pin_box">
-          <ul className="pin_list">
-            {userList.map((user) => {
-              return (
-                <li key={user} className={classNames('pin_item shadow_m')}>
-                  <span className="user" style={{ margin: '0px' }}>
-                    <span className={`icon gradient_180deg_${UserColors[user]}`}></span>
-                    <span className="text">{UserNames[user]}</span>
-                  </span>
-                  <div className="btn_box">
-                    <button
-                      type="button"
-                      className={classNames('btn btn_line btn_pin')}
-                      title="Pin"
-                      onClick={() => {
-                        deleteUser(user);
-                      }}
-                    >
-                      <Icon type="close" />
-                    </button>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-          <button type="button" className="btn btn_add" onClick={addUser}>
-            <Icon type="plus" />
-          </button>
-        </div>
-
-        <ul className="grid_list2">
-          {userList.map((user) => {
-            return <UserContent key={user} user={user} iframeURL={iframeURL} />;
+    <div className="content code_view">
+      <div className="pin_box">
+        <ul className="pin_list">
+          {userList.map((userNumber) => {
+            return (
+              <li key={userNumber} className={classNames('pin_item shadow_m')}>
+                <span className="user">
+                  <span className={`icon gradient_180deg_${UserColors[userNumber % UserColors.length]}`}></span>
+                  <span className="text">{`User ${userNumber}`}</span>
+                </span>
+                <div className="btn_box">
+                  <button
+                    type="button"
+                    className={classNames('btn btn_line btn_pin')}
+                    title="Pin"
+                    onClick={() => {
+                      deleteUser(userNumber);
+                    }}
+                  >
+                    <Icon type="close" />
+                  </button>
+                </div>
+              </li>
+            );
           })}
         </ul>
-
-        <div className="log_box">
-          <div className="log_inner">
-            <div className="log_title">Event Log</div>
-            <div style={{ overflowY: 'auto', paddingLeft: 3, maxHeight: 113 - 18 - 5, fontSize: 12 }}>
-              {docChangeInfos.map((changeInfo, index) => (
-                <div className="log_desc" key={index}>
-                  <span style={{ fontWeight: 'bold' }}>event</span> -{' '}
-                  {changeInfo.type === 'update' && <span style={{ opacity: 0.5 }}>modification occured at </span>}
-                  <span>{changeInfo.content}</span>
-                </div>
-              ))}
-              <div ref={messagesEndRef} />
-            </div>
+        <button type="button" className="btn btn_add" onClick={addUser}>
+          <Icon type="plus" />
+        </button>
+      </div>
+      <ul className="grid_list2">
+        {userList.map((userNumber) => {
+          return <UserContent key={userNumber} userNumber={userNumber} iframeURL={iframeURL} />;
+        })}
+      </ul>
+      <div className="log_box">
+        <div className="log_inner">
+          <div className="log_title">Event Log</div>
+          <div style={{ overflowY: 'auto', paddingLeft: 3, maxHeight: 113 - 18 - 5, fontSize: 12 }}>
+            {docChangeInfos.map((changeInfo, index) => (
+              <div className="log_desc" key={index}>
+                <span style={{ fontWeight: 'bold' }}>event</span> -
+                {changeInfo.type === 'update' && <span style={{ opacity: 0.5 }}>modification occured at </span>}
+                <span>{changeInfo.content}</span>
+              </div>
+            ))}
+            <div ref={messagesEndRef} />
           </div>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/components/BasicExample/ProjectCodes.tsx
+++ b/components/BasicExample/ProjectCodes.tsx
@@ -123,7 +123,7 @@ function ProjectCodes({ code, setProjectCodeState }: Props) {
       <div className="codeblock_area">
         <em className="file_title">{openedFile.name}</em>
         <div className="codeblock_box">
-          <CodeBlock code={openedFile.content} language="javascript" withLineNumbers />
+          <CodeBlock code={openedFile.content} language={openedFile.language} withLineNumbers />
         </div>
       </div>
     </div>

--- a/components/BasicExample/Sidebar.tsx
+++ b/components/BasicExample/Sidebar.tsx
@@ -64,9 +64,9 @@ export function Sidebar({ defaultOpened = true, title, description, projectCode,
           </div>
         )}
       </div>
-      <div className="sidebar_bottom" style={{ zIndex: 0 }}>
+      <div className="sidebar_bottom">
         <div className="btn_box">
-          <a href={codeURL} className="btn gray600 ">
+          <a href={codeURL} className="btn gray600" target="_blank" rel="noreferrer">
             GitHub
           </a>
         </div>

--- a/components/BasicExample/UserContent.tsx
+++ b/components/BasicExample/UserContent.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { UserColors, UserNames } from './BasicExampleView';
+import { UserColors } from './BasicExampleView';
 
-function UserContent({ user, iframeURL }: { user: 'user1' | 'user2' | 'user3' | 'user4'; iframeURL: string }) {
+function UserContent({ userNumber, iframeURL }: { userNumber: number; iframeURL: string }) {
   return (
-    <li className="grid_item shadow_m" key={user}>
-      <div className="dashboard" style={{ height: '100%' }}>
+    <li className="grid_item shadow_m" key={userNumber}>
+      <div className="dashboard">
         <div className="dashboard_top">
-          <span className={`user gradient_180deg_${UserColors[user]}`}>{UserNames[user]}</span>
+          <span className={`user gradient_180deg_${UserColors[userNumber % UserColors.length]}`}>
+            {`User ${userNumber}`}
+          </span>
         </div>
-        <div className="dashboard_content" style={{ flex: '1 0' }}>
+        <div className="dashboard_content">
           <iframe title="Example" frameBorder="0" src={iframeURL} width="100%" height="100%"></iframe>
         </div>
       </div>

--- a/components/BasicExample/index.tsx
+++ b/components/BasicExample/index.tsx
@@ -1,2 +1,3 @@
 export * from './BasicExampleView';
 export * from './types';
+export * from './Sidebar';

--- a/examples/profile-stack/documentStructure.ts
+++ b/examples/profile-stack/documentStructure.ts
@@ -1,0 +1,2 @@
+export const DocumentStructure = `
+`;

--- a/examples/profile-stack/files/.env.production.js
+++ b/examples/profile-stack/files/.env.production.js
@@ -1,0 +1,5 @@
+export const language = 'javascript';
+export const content = `
+VITE_YORKIE_API_ADDR='https://api.yorkie.dev'
+VITE_YORKIE_API_KEY='cedaovjuioqlk4pjqn6g'
+`;

--- a/examples/profile-stack/files/index.html.js
+++ b/examples/profile-stack/files/index.html.js
@@ -1,0 +1,19 @@
+export const language = 'markup';
+export const content = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Profile Stack - Yorkie Example</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div id="peerList"></div>
+    </div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>
+`;

--- a/examples/profile-stack/files/index.ts
+++ b/examples/profile-stack/files/index.ts
@@ -1,0 +1,17 @@
+import * as styleCss from './style.css';
+import * as mainJs from './main.js';
+import * as packageJson from './package.json';
+import * as indexHtml from './index.html';
+import * as utilJs from './util.js';
+import * as env from './.env.production.js';
+
+import { Language } from 'prism-react-renderer';
+
+export const files: { [key: string]: { language: Language; content: string } } = {
+  'style.css': { language: styleCss.language, content: styleCss.content },
+  'main.js': { language: mainJs.language, content: mainJs.content },
+  'package.json': { language: packageJson.language, content: packageJson.content },
+  'index.html': { language: indexHtml.language, content: indexHtml.content },
+  'util.js': { language: utilJs.language, content: utilJs.content },
+  '.env.production': { language: env.language, content: env.content },
+};

--- a/examples/profile-stack/files/main.js
+++ b/examples/profile-stack/files/main.js
@@ -1,0 +1,91 @@
+export const language = 'javascript';
+export const content = `
+import yorkie from 'yorkie-js-sdk';
+import { getRandomName, getRandomColor } from './util.js';
+
+async function main() {
+  const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
+    apiKey: import.meta.env.VITE_YORKIE_API_KEY,
+    // set the client's name and color to presence.
+    presence: {
+      name: getRandomName(),
+      color: getRandomColor(),
+    },
+  });
+  await client.activate();
+  const myClientID = client.getID();
+
+  const doc = new yorkie.Document('profile-stack');
+  await client.attach(doc);
+
+  client.subscribe((event) => {
+    if (event.type === 'peers-changed') {
+      // get presence of all clients connected to the Document. 
+      // {<clientID>: {name: string, color: string}}
+      const peers = event.value[doc.getKey()];
+
+      // show peer list
+      displayPeerList(peers, myClientID);
+    }
+  });
+}
+
+const MAX_PEER_VIEW = 4;
+const createPeer = (name, color, type) => {
+  const $peer = document.createElement('div');
+  $peer.className = 'peer';
+
+  if (type === 'main') {
+    $peer.innerHTML = \`
+    <div class="profile">
+      <img src="./images/profile-\${color}.svg" alt="profile" class="profile-img"/>
+    </div>
+    <div class="name speech-bubbles">\${name}</div>
+  \`;
+  } else if (type === 'more') {
+    $peer.innerHTML = \`
+    <img src="./images/profile-\${color}.svg" alt="profile" class="profile-img"/>
+    <span class="name">\${name}</span>
+  \`;
+  }
+  return $peer;
+};
+
+const displayPeerList = (peers, myClientID) => {
+  const peerList = Object.entries(peers).filter(([id]) => id !== myClientID);
+  const peerCount = peerList.length + 1;
+  const hasMorePeers = peerCount > MAX_PEER_VIEW;
+  const $peerList = document.getElementById('peerList');
+  $peerList.innerHTML = '';
+  const $peerMoreList = document.createElement('div');
+  $peerMoreList.className = 'peer-more-list speech-bubbles';
+
+  const myInfo = peers[myClientID];
+  const $me = createPeer(\`\${myInfo.name} (me)\`, myInfo.color, 'main');
+  $me.classList.add('me');
+  $peerList.appendChild($me);
+  peerList.forEach(([_, { name, color }], i) => {
+    if (i < MAX_PEER_VIEW - 1) {
+      const $peer = createPeer(name, color, 'main');
+      $peerList.appendChild($peer);
+      return;
+    }
+    const $peer = createPeer(name, color, 'more');
+    $peerMoreList.appendChild($peer);
+  });
+
+  if (hasMorePeers) {
+    const $peer = document.createElement('div');
+    $peer.className = 'peer more';
+    $peer.innerHTML = \`
+      <div class="profile">
+      +\${peerCount - MAX_PEER_VIEW}
+      </div>
+    \`;
+    $peer.appendChild($peerMoreList);
+    $peerList.appendChild($peer);
+  }
+};
+
+main();
+`;

--- a/examples/profile-stack/files/package.json.js
+++ b/examples/profile-stack/files/package.json.js
@@ -1,0 +1,20 @@
+export const language = 'json';
+export const content = `
+{
+  "name": "profile-stack",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^3.2.3"
+  },
+  "dependencies": {
+    "yorkie-js-sdk": "^0.2.19"
+  }
+}
+`;

--- a/examples/profile-stack/files/style.css.js
+++ b/examples/profile-stack/files/style.css.js
@@ -1,0 +1,128 @@
+export const language = 'css';
+export const content = `
+* {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  --light-gray: #f5f3f1;
+  --gray: #c2bdba;
+  --black: #332e2b;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  color: var(--black);
+}
+
+img {
+  vertical-align: top;
+}
+
+.speech-bubbles {
+  padding: 16px;
+  border: 1px solid var(--gray);
+  border-radius: 16px;
+}
+
+.speech-bubbles:before {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  margin-left: -6px;
+  margin-top: -8px;
+  width: 0;
+  height: 0;
+  content: '';
+  border-top: 0px solid transparent;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 8px solid var(--gray);
+}
+
+.speech-bubbles:after {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  margin-left: -5px;
+  margin-top: -6px;
+  width: 0;
+  height: 0;
+  content: '';
+  border-top: 0px solid transparent;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 7px solid white;
+}
+
+#peerList {
+  display: inline-flex;
+  border: 1px solid var(--gray);
+  border-radius: 100px;
+  white-space: nowrap;
+}
+
+.peer {
+  position: relative;
+  margin: 12px;
+}
+
+.profile-img {
+  width: 52px;
+  cursor: pointer;
+}
+
+.peer.me {
+  order: -1;
+}
+
+.peer .name {
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.peer .speech-bubbles {
+  display: none;
+  position: absolute;
+  top: 80px;
+  left: 50%;
+  transform: translate(-50%);
+}
+
+.peer:hover .speech-bubbles {
+  display: block;
+}
+
+.peer.more {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 52px;
+  height: 52px;
+  background: var(--light-gray);
+  border-radius: 100%;
+  font-weight: 900;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.peer-more-list {
+  font-size: 16px;
+}
+
+.peer-more-list .peer {
+  display: flex;
+  align-items: center;
+  margin: 0 0 12px 0;
+}
+
+.peer-more-list .peer:last-child {
+  margin-bottom: 0;
+}
+
+.peer-more-list .profile-img {
+  margin-right: 8px;
+  width: 26px;
+}
+`;

--- a/examples/profile-stack/files/util.js
+++ b/examples/profile-stack/files/util.js
@@ -1,0 +1,27 @@
+export const language = 'javascript';
+export const content = `
+const NAMES = [
+'Ali',
+  'Beatriz',
+  'Charles',
+  'Diya',
+  'Eric',
+  'Fatima',
+  'Gabriel',
+  'Hanna',
+  'Johnson',
+  'Perry',
+  'Parker',
+  'Kelly',
+];
+export const getRandomName = () => {
+  const index = Math.floor(Math.random() * NAMES.length);
+  return NAMES[index];
+};
+
+const COLORS = ['red', 'yellow', 'orange', 'green', 'blue', 'purple'];
+export const getRandomColor = () => {
+  const index = Math.floor(Math.random() * COLORS.length);
+  return COLORS[index];
+};
+`;

--- a/examples/profile-stack/index.ts
+++ b/examples/profile-stack/index.ts
@@ -1,0 +1,2 @@
+export * from './documentStructure';
+export * from './projectCode';

--- a/examples/profile-stack/projectCode.ts
+++ b/examples/profile-stack/projectCode.ts
@@ -1,0 +1,50 @@
+import { ProjectCodeType } from '@/components/BasicExample';
+import { files } from './files';
+
+export const ProjectCode: ProjectCodeType = {
+  name: 'profile-stack',
+  children: [
+    {
+      isFile: true,
+      isOpen: false,
+      language: files['index.html'].language,
+      name: 'index.html',
+      content: files['index.html'].content,
+    },
+    {
+      isFile: true,
+      isOpen: true,
+      language: files['main.js'].language,
+      name: 'main.js',
+      content: files['main.js'].content,
+    },
+    {
+      isFile: true,
+      isOpen: false,
+      language: files['style.css'].language,
+      name: 'style.css',
+      content: files['style.css'].content,
+    },
+    {
+      isFile: true,
+      isOpen: false,
+      language: files['util.js'].language,
+      name: 'util.js',
+      content: files['util.js'].content,
+    },
+    {
+      isFile: true,
+      isOpen: false,
+      language: files['package.json'].language,
+      name: 'package.json',
+      content: files['package.json'].content,
+    },
+    {
+      isFile: true,
+      isOpen: false,
+      language: files['.env.production'].language,
+      name: '.env.production',
+      content: files['.env.production'].content,
+    },
+  ],
+};

--- a/pages/examples/index.tsx
+++ b/pages/examples/index.tsx
@@ -165,17 +165,15 @@ const Examples: NextPage = () => {
               </Link>
             </li>
             <li className="grid_item">
-              <a href="/examples/profile-stack" className="grid_card">
+              <Link href="/examples/profile-stack" className="grid_card">
                 <div className="grid_thumbnail">
                   <ExampleStatusSVG />
                 </div>
                 <div className="grid_card_info">
                   <strong className="title">Profile Stack</strong>
-                  <p className="desc">
-                    Profile stack display indicates other collaborators’ current task with a status icon.
-                  </p>
+                  <p className="desc">Profile stack shows the list of users currently accessing the Document.</p>
                 </div>
-              </a>
+              </Link>
             </li>
             {/* <li className="grid_item">
               <Link href="/examples/multi-cursor" className="grid_card">

--- a/pages/examples/kanban.tsx
+++ b/pages/examples/kanban.tsx
@@ -1,8 +1,8 @@
 import { NextPage } from 'next';
 import Head from 'next/head';
 import { ExampleLayout } from '@/components';
-import { BasicExampleView } from '@/components/BasicExample';
-import { DocumentStructure, ProjectCode } from '../../examples/kanban';
+import { BasicExampleView, Sidebar } from '@/components/BasicExample';
+import { DocumentStructure, ProjectCode } from '@/examples/kanban';
 
 export interface DocChangeInfo {
   type: 'modification' | 'initialize';
@@ -11,20 +11,25 @@ export interface DocChangeInfo {
 
 const KanbanExampleView: NextPage = () => {
   return (
-    <ExampleLayout breadcrumbTitle="Kanban Board" defaultViewType="split">
+    <ExampleLayout breadcrumbTitle="Kanban Board">
       {({ viewType }) => (
         <>
           <Head>
             <title>Kanban Board · Yorkie Examples</title>
           </Head>
+          <Sidebar
+            title="Kanban Board"
+            description="Kanban Board is a tool for managing tasks and workflow. It is a visual way to manage tasks and workflow."
+            codeURL="https://github.com/yorkie-team/yorkie-js-sdk/tree/main/examples/vuejs-kanban"
+            projectCode={ProjectCode}
+            documentStructure={DocumentStructure}
+            defaultOpened
+          />
           <BasicExampleView
             rpcAddr={process.env.NEXT_PUBLIC_API_ADDR || ''}
             apiKey={process.env.NEXT_PUBLIC_EXAMPLES_API_KEY || ''}
             documentKey="vuejs-kanban"
-            projectCode={ProjectCode}
-            documentStructure={DocumentStructure}
             iframeURL="https://yorkie.dev/yorkie-js-sdk/examples/vuejs-kanban/"
-            codeURL="https://github.com/yorkie-team/yorkie-js-sdk/tree/main/examples/vuejs-kanban"
           />
         </>
       )}

--- a/pages/examples/profile-stack.tsx
+++ b/pages/examples/profile-stack.tsx
@@ -1,0 +1,41 @@
+import { NextPage } from 'next';
+import Head from 'next/head';
+import { ExampleLayout } from '@/components';
+import { BasicExampleView, Sidebar } from '@/components/BasicExample';
+import { DocumentStructure, ProjectCode } from '@/examples/profile-stack';
+
+export interface DocChangeInfo {
+  type: 'modification' | 'initialize';
+  path: string;
+}
+
+const ProfileStackExampleView: NextPage = () => {
+  return (
+    <ExampleLayout breadcrumbTitle="Profile Stack">
+      {() => (
+        <>
+          <Head>
+            <title>Profile Stack · Yorkie Examples</title>
+          </Head>
+          <Sidebar
+            title="Profile Stack"
+            description="The profile stack shows the list of users currently accessing the Document. Try adding and deleting users to see how the profile stack changes."
+            codeURL="https://github.com/yorkie-team/yorkie-js-sdk/tree/main/examples/profile-stack"
+            projectCode={ProjectCode}
+            documentStructure={DocumentStructure}
+            defaultOpened
+          />
+          <BasicExampleView
+            rpcAddr={process.env.NEXT_PUBLIC_API_ADDR || ''}
+            apiKey={process.env.NEXT_PUBLIC_EXAMPLES_API_KEY || ''}
+            documentKey="profile-stack"
+            iframeURL="https://yorkie.dev/yorkie-js-sdk/examples/profile-stack/"
+            userMaxCount={6}
+          />
+        </>
+      )}
+    </ExampleLayout>
+  );
+};
+
+export default ProfileStackExampleView;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- [x] Add profile-stack example

![image](https://user-images.githubusercontent.com/81357083/208642782-f8ce3732-422b-42c3-9fc7-0f3df54ce553.png)

- When multiple users access the profile-stack example page, the number of users does not match the actual number of users who access the document because the document key is the same. Would it be better to access the example page with a new document key?
  - In the example below, two users are displayed on the page, but four are displayed in the iframe. 
![image](https://user-images.githubusercontent.com/81357083/208643802-3f17e4f8-1ad2-4102-83ca-b115a95cf089.png)

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
