### PR TITLE
Fix typos in main page & mobile dropdown

### DIFF
--- a/components/Layout/MobileGnbDropdown.tsx
+++ b/components/Layout/MobileGnbDropdown.tsx
@@ -145,7 +145,7 @@ export function MobileGnbDropdown({ isLoggedIn }: { isLoggedIn: boolean }) {
                 href="/examples"
                 className={classNames('dropdown_menu', { is_active: asPath.split('#')[0] === '/examples' })}
               >
-                <span className="dropdown_text">Example</span>
+                <span className="dropdown_text">Examples</span>
               </Link>
             </li>
             <li className="dropdown_item">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -106,8 +106,7 @@ const Home: NextPage = () => {
             Variety of <br className="br_mo" /> collaboration features <br /> for your app
           </h2>
           <p className="section_desc">
-            Easily add stable and diverse collaborative features
-            <br className="br_mo" />
+            Easily add stable and diverse collaborative features <br className="br_mo" />
             to your product with Yorkie. <br />
             Transform your local-based product into a <br className="br_mo" /> collaborative online experience with our
             powerful tools. <br />


### PR DESCRIPTION
#### What this PR does / why we need it?

1. Fix typo in main page: `featuresto` -> `features to`
  ![pr1](https://user-images.githubusercontent.com/70474071/211778343-acc5b805-8234-449b-8a64-37e1f8eae95a.PNG)

2. Fix typo in mobile dropdown: `example` -> `examples`
  ![pr2](https://user-images.githubusercontent.com/70474071/211778351-ce5f3cb1-8f51-451e-b409-bbdbbbd95ad8.PNG)

#### Any background context you want to provide?

#### What are the relevant tickets?

Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
