### PR TITLE
Fix CLI page link in main page & mobile dropdown

### DIFF
--- a/components/Layout/MobileGnbDropdown.tsx
+++ b/components/Layout/MobileGnbDropdown.tsx
@@ -109,12 +109,12 @@ export function MobileGnbDropdown({ isLoggedIn }: { isLoggedIn: boolean }) {
                   </li>
                   <li className="navigator_group">
                     <Link
-                      href="/docs/project"
+                      href="/docs/cli"
                       className={classNames('navigator_item', 'add_icon', {
-                        is_active: asPath.startsWith(`/docs/project`),
+                        is_active: asPath.startsWith(`/docs/cli`),
                       })}
                     >
-                      Project
+                      CLI
                     </Link>
                   </li>
                   <li className="navigator_group">

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -103,7 +103,7 @@ Flags:
 
 ### Project
 
-Project represents your service or application in Yorkie. Separate Projects can exist within a single application. You can add more Projects as needed, for example, if you want to manage [auth webhook](/docs/project#auth-webhook) and documents for specific purposes.
+Project represents your service or application in Yorkie. Separate Projects can exist within a single application. You can add more Projects as needed, for example, if you want to manage [auth webhook](/docs/cli#auth-webhook) and documents for specific purposes.
 
 To manage Projects, you can use the `project` subcommand:
 

--- a/pages/products.tsx
+++ b/pages/products.tsx
@@ -191,7 +191,7 @@ const Products: NextPage = () => {
               <li className="product_card_item">
                 <strong className="product_card_title">Security</strong>
                 <p className="product_card_desc">
-                  <Link href="/docs/project#auth-webhook" className="link">
+                  <Link href="/docs/cli#auth-webhook" className="link">
                     Auth Webhook
                   </Link>{' '}
                   allows users to verify the authorization of clients to access documents from an external service.


### PR DESCRIPTION
#### What this PR does / why we need it?

1. Fix wrong page link: `/docs/project` -> `/docs/cli`
  ![pr1](https://user-images.githubusercontent.com/70474071/212283721-e3be9227-a6c6-4620-9076-822948c684ee.PNG)
2. Fix mobile dropdown's wrong page link:  `Project` -> `CLI`
  ![pr2](https://user-images.githubusercontent.com/70474071/212283732-7d3b8bf5-4976-4a77-8a86-177b619eab48.PNG)

#### Any background context you want to provide?

#### What are the relevant tickets?

Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
