### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
         id: detect-package-manager
         run: |
           if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "::set-output name=manager::yarn"
-            echo "::set-output name=command::install"
-            echo "::set-output name=runner::yarn"
+            echo "manager=yarn" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=yarn" >> $GITHUB_OUTPUT
             exit 0
           elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "::set-output name=manager::npm"
-            echo "::set-output name=command::ci"
-            echo "::set-output name=runner::npx --no-install"
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
             exit 0
           else
             echo "Unable to determine packager manager"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,14 +34,14 @@ jobs:
         id: detect-package-manager
         run: |
           if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "::set-output name=manager::yarn"
-            echo "::set-output name=command::install"
-            echo "::set-output name=runner::yarn"
+            echo "manager=yarn" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=yarn" >> $GITHUB_OUTPUT
             exit 0
           elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "::set-output name=manager::npm"
-            echo "::set-output name=command::ci"
-            echo "::set-output name=runner::npx --no-install"
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
             exit 0
           else
             echo "Unable to determine packager manager"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Update workflows to use environment file instead of deprecated `set-output` command. 

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
if [ -f "${{ github.workspace }}/yarn.lock" ]; then
  echo "::set-output name=manager::yarn"
  echo "::set-output name=command::install"
  echo "::set-output name=runner::yarn"
  exit 0
elif [ -f "${{ github.workspace }}/package.json" ]; then
  echo "::set-output name=manager::npm"
  echo "::set-output name=command::ci"
  echo "::set-output name=runner::npx --no-install"
  exit 0
else
```

**TO-BE**

```yml
if [ -f "${{ github.workspace }}/yarn.lock" ]; then
  echo "manager=yarn" >> $GITHUB_OUTPUT
  echo "command=install" >> $GITHUB_OUTPUT
  echo "runner=yarn" >> $GITHUB_OUTPUT
  exit 0
elif [ -f "${{ github.workspace }}/package.json" ]; then
  echo "manager=npm" >> $GITHUB_OUTPUT
  echo "command=ci" >> $GITHUB_OUTPUT
  echo "runner=npx --no-install" >> $GITHUB_OUTPUT
  exit 0
else
```

#### Any background context you want to provide?

For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #68 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
