### PR TITLE
Use composite action for package manager detection

### DIFF
--- a/.github/actions/detect-package-manager/action.yml
+++ b/.github/actions/detect-package-manager/action.yml
@@ -1,0 +1,44 @@
+name: Detect Package Manager
+description: Detects the package manager used by the project
+
+inputs:
+  path:
+    description: The path where the package manager should be detected
+    required: false
+    default: ${{ github.workspace }}
+
+outputs:
+  manager:
+    description: The package manager used by the project
+    value: ${{ steps.detect-package-manager.outputs.manager }}
+  command:
+    description: The command to run to install dependencies
+    value: ${{ steps.detect-package-manager.outputs.command }}
+  runner:
+    description: The command to run to execute a script
+    value: ${{ steps.detect-package-manager.outputs.runner }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Detect Package Manager
+      id: detect-package-manager
+      shell: bash
+      env:
+        PROJECT_PATH: ${{ inputs.path }}
+      run: |
+        if [ -f "$PROJECT_PATH/yarn.lock" ]; then
+          echo "manager=yarn" >> $GITHUB_OUTPUT
+          echo "command=install" >> $GITHUB_OUTPUT
+          echo "runner=yarn" >> $GITHUB_OUTPUT
+          exit 0
+        elif [ -f "$PROJECT_PATH/package-lock.json" ]; then
+          echo "manager=npm" >> $GITHUB_OUTPUT
+          echo "command=ci" >> $GITHUB_OUTPUT
+          echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+          exit 0
+        else
+          echo "Unable to determine packager manager at $PROJECT_PATH"
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Detect package manager
         id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine packager manager"
-            exit 1
-          fi
+        uses: ./.github/actions/detect-package-manager
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,21 +32,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Detect package manager
         id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine packager manager"
-            exit 1
-          fi
+        uses: ./.github/actions/detect-package-manager
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

For each workflow, the package manager detection step is written in the same code:

```yaml
- name: Detect package manager
  id: detect-package-manager
  run: |
    if [ -f "${{ github.workspace }}/yarn.lock" ]; then
      echo "manager=yarn" >> $GITHUB_OUTPUT
      echo "command=install" >> $GITHUB_OUTPUT
      echo "runner=yarn" >> $GITHUB_OUTPUT
    exit 0
    elif [ -f "${{ github.workspace }}/package.json" ]; then
      echo "manager=npm" >> $GITHUB_OUTPUT
      echo "command=ci" >> $GITHUB_OUTPUT
      echo "runner=npx --no-install" >> $GITHUB_OUTPUT
    exit 0
    else
      echo "Unable to determine packager manager"
      exit 1
    fi
```

If requirements change, we'll need to edit it for each workflow. This makes maintenance difficult and can lead to mistakes.

Duplicate workflow steps can be abstracted into [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).

```yaml
- name: Detect package manager
  id: detect-package-manager
  uses: ./.github/actions/detect-package-manager
```

See also https://docs.github.com/en/actions/creating-actions/creating-a-composite-action, https://blog.outsider.ne.kr/1592

#### Any background context you want to provide?

None

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #87 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
