### PR TITLE
Remove gRPC-web and Envoy (replaced by ConnectRPC)

### DIFF
--- a/docs/self-hosted-server.mdx
+++ b/docs/self-hosted-server.mdx
@@ -42,59 +42,6 @@ serving profiling on 11102
 serving RPC on 11101
 ```
 
-### Server for Web
-
-Server uses [gRPC](https://grpc.io/) to provide an API that Clients can connect to. Since it is currently impossible to implement the HTTP/2 gRPC in some browsers, [Envoy](https://www.envoyproxy.io/) is required for web. For more details: [gRPC-web](https://grpc.io/blog/state-of-grpc-web/)
-
-This page shows how to start the Server for web. Overall structure is as follows:
-
-```
- Browser            Envoy                  Server
-┌────────┐         ┌──────────────┐       ┌───────────┐
-│gRPC-web├─HTTP1.1─┤gRPC-web Proxy├─HTTP2─┤gRPC Server│
-└────────┘         └──────────────┘       └───────────┘
-```
-
-Configuring Envoy by hand with its config file is cumbersome, but using [Docker Compose](https://docs.docker.com/compose/) makes it easy.
-
-<Alert status="warning">If docker compose is not installed, install it : [Install Docker Compose](https://docs.docker.com/compose/install/)</Alert>
-
-First, download all manifest files from [docker folder](https://github.com/yorkie-team/yorkie-team.github.io/tree/main/docker). Then, execute the following command in the folder containing the downloaded file.
-
-```bash
-$ docker-compose up --build -d
-
-Starting yorkie ... done
-Starting envoy  ... done
-```
-
-This will launch Yorkie(Server) and envoy containers on your environment.
-
-```bash
-$ docker ps
-
-IMAGE                      COMMAND                  PORTS                                  NAMES
-grpcweb:envoy              "/usr/local/bin/envo…"   0.0.0.0:8080->8080/tcp                 envoy
-yorkieteam/yorkie:latest   "yorkie server --ena…"   0.0.0.0:11101-11102->11101-11102/tcp   yorkie
-```
-
-Then, the ports of the services are bound to the host environment.
-
-- 8080: gRPC-web port for RPC Server, including SDK and Admin
-- 11101: gRPC port for RPC Server, including SDK and Admin
-- 11102: HTML port for Profiling Server
-
-<Alert status="warning">Server stores its data using an in-memory DB, which does not provide durability. If you want to store data permanently, please refer to [Running Server With MongoDB](/docs/self-hosted-server#running-server-with-mongodb)</Alert>
-
-Now, let's create a Client with address `{{API_ADDR}}`.
-
-```javascript
-const client = new yorkie.Client('{{API_ADDR}}');
-await client.activate();
-```
-
-Next, let's take a look at the [JS SDK](/docs/js-sdk).
-
 ### Monitoring
 
 Server exports metrics under the `/metrics` path on its profiling port.


### PR DESCRIPTION
#### What this PR does / why we need it?

Remove gRPC-web and Envoy part from “Self-Hosted Server” part of the document.

#### Any background context you want to provide?

https://github.com/yorkie-team/yorkie-js-sdk/pull/698 introduced ConnectRPC to replace gRPC-web and Envoy.
Now we can connect to Yorkie Server from JavaScript SDK directly.

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the self-hosted server documentation to focus on monitoring metrics export, removing detailed setup instructions for gRPC and Envoy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->