### PR TITLE
Fix Invalid Boolean MobileHeader

### DIFF
--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -70,7 +70,7 @@ export function Header(): ReactElement {
               </Button>
             </>
           ) : null}
-          <MobileGnbDropdown isLoggedIn={!isLoggedIn} />
+          <MobileGnbDropdown isLoggedIn={!!isLoggedIn} />
         </div>
       </div>
     </header>


### PR DESCRIPTION
#### What this PR does / why we need it?

Previously, there was an issue where the !isLoggedIn value was passed as a prop to MobileGnbDropDown, causing false value to be passed as props. This PR corrects the logic to ensure the correct value of 'isLoggedIn' is passed as props.

#### Any background context you want to provide?

The issue stemmed from passing the !isLoggedIn value instead of the actual 'isLoggedIn' value to MobileGnbDropDown component as props, leading to unexpected behavior. By addressing this, the correct value will be passed and utilized in the component.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie-team.github.io/issues/146

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of the login status indicator in the mobile dropdown menu to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->