### PR TITLE
Update docs for Istio installation

### DIFF
--- a/docs/self-hosted-server.mdx
+++ b/docs/self-hosted-server.mdx
@@ -14,8 +14,6 @@ To run a Yorkie Server, you need to install the CLI. If you haven't installed it
 Let's start a Server with the CLI. You can start a Server with the following command:
 
 ```bash
-
-```bash
 $ yorkie server
 
 backend created: id: cppoq5huevgut6tjo8qg, db: memory

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -62,7 +62,13 @@ After ingress addons are enabled, you will see the following output:
 After Minikube is configured, you need to install Istio for Yorkie cluster.
 Yorkie cluster uses Istio for L7 load balancing and traffic management.
 
-Install Istio with the following command:
+First, create the `yorkie` namespace:
+
+```bash
+$ kubectl create namespace yorkie
+```
+
+Then, install Istio with the following command:
 
 ```bash
 $ istioctl install -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-operator.yaml)

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -97,25 +97,9 @@ Making this installation the default for injection and validation.
 Thank you for installing Istio 1.17.  Please take a few minutes to tell us about your install/upgrade experience!  https://forms.gle/hMHGiwZHPU7UQRWe9
 ```
 
-### Add yorkie-team Helm chart in your local repository
-
-After Istio is installed, you need to add yorkie-team Helm chart repository in your local repository to install Yorkie cluster.
-
-Add yorkie-team Helm chart repository in your local repository with the following command:
-
-```bash
-$ helm repo add yorkie-team https://yorkie-team.github.io/yorkie/helm-charts
-```
-
-Then, update your local repository with the following command:
-
-```bash
-$ helm repo update
-```
-
 ### Setup MongoDB pod and service
 
-Before installing the Yorkie cluster with Helm chart, you need to set up a MongoDB pod and expose it as a service. This is crucial since internal MongoDB installation is no longer provided and it avoids errors during Yorkie server provisioning.
+Before installing the Yorkie cluster with Helm chart, you need to set up a MongoDB pod and expose it as a service. This is crucial since internal MongoDB installation is no longer provided.
 
 First, create the `mongodb` namespace with the following command:
 
@@ -136,6 +120,22 @@ $ kubectl expose pod mongodb --port=27017 --target-port=27017 --name=mongodb --t
 ```
 
 By following these steps, you ensure that the MongoDB pod is running and accessible to other pods within the cluster.
+
+### Add yorkie-team Helm chart in your local repository
+
+After Istio is installed, you need to add yorkie-team Helm chart repository in your local repository to install Yorkie cluster.
+
+Add yorkie-team Helm chart repository in your local repository with the following command:
+
+```bash
+$ helm repo add yorkie-team https://yorkie-team.github.io/yorkie/helm-charts
+```
+
+Then, update your local repository with the following command:
+
+```bash
+$ helm repo update
+```
 
 ### Install Yorkie cluster with Helm chart
 

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -62,7 +62,7 @@ After ingress addons are enabled, you will see the following output:
 After Minikube is configured, you need to install Istio for Yorkie cluster.
 Yorkie cluster uses Istio for L7 load balancing and traffic management.
 
-First, create the `yorkie` namespace:
+First, create the `yorkie` namespace with the following command:
 
 ```bash
 $ kubectl create namespace yorkie
@@ -112,6 +112,30 @@ Then, update your local repository with the following command:
 ```bash
 $ helm repo update
 ```
+
+### Setup MongoDB pod and service
+
+Before installing the Yorkie cluster with Helm chart, you need to set up a MongoDB pod and expose it as a service. This is crucial since internal MongoDB installation is no longer provided and it avoids errors during Yorkie server provisioning.
+
+First, create the `mongodb` namespace with the following command:
+
+```bash
+$ kubectl create namespace mongodb
+```
+
+Then, create a MongoDB pod named `mongodb` in the `mongodb` namespace with the following command:
+
+```bash
+$ kubectl run mongodb --image=mongo:latest --port=27017 -n mongodb
+```
+
+Next, expose the MongoDB pod as a service to allow other pods to access it with the following command:
+
+```bash
+$ kubectl expose pod mongodb --port=27017 --target-port=27017 --name=mongodb --type=ClusterIP -n mongodb
+```
+
+By following these steps, you ensure that the MongoDB pod is running and accessible to other pods within the cluster.
 
 ### Install Yorkie cluster with Helm chart
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This pull request aims to add a namespace creation step in the Istio installation instructions. The absence of a specific namespace can result in errors like the following during the installation process.
``` bash
✘ Ingress gateways encountered an error: failed to update resource with server-side apply for obj ServiceAccount/yorkie/yorkie-gateway-service-account: namespaces "yorkie" not found
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions for Istio in the Yorkie cluster setup to include the creation of a dedicated `yorkie` namespace as a prerequisite, enhancing clarity and correctness.
	- Added a new section for setting up a MongoDB pod and service, detailing the necessary commands and emphasizing the removal of internal MongoDB installation.
	- Streamlined the documentation for starting a Yorkie Server by removing unnecessary blank code blocks for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->