### PR TITLE
Add explanation for Filtering Presence Changes in Documentation

### DIFF
--- a/docs/devtools.mdx
+++ b/docs/devtools.mdx
@@ -72,7 +72,8 @@ Within the `Yorkie 🐾` panel, you will find the `History` panel at the top, th
 - Easily debug through time-travel and replay.
     - Move the slider and click on an event to check event details and see how the document has changed.
     - Convenient navigation is possible using the arrow buttons at the top right or using the directional keys.
-
+    - If you are only interested in document changes, click the `Y` button next to the navigation buttons to filter out presence changes, and toggle it again to undo.
+    
 <video autoPlay loop muted playsInline style={{ maxWidth: '900px' }}>
     <source src="/assets/images/docs/devtools-history.mov"/>
 </video>


### PR DESCRIPTION
Updated the documentation to provide instructions on how to filter out presence changes.

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Since presence event filter has been added to devtools, the document needs to be updated accordingly.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #151 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced filtering options in the `Yorkie 🐾` panel's `History` section, allowing users to focus on document modifications.
	- Added a toggle feature to easily switch between viewing all changes and filtered changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->