### PR TITLE
Update docs for CodePair setup

### DIFF
--- a/docs/self-hosted-server/aws-eks.mdx
+++ b/docs/self-hosted-server/aws-eks.mdx
@@ -176,38 +176,15 @@ Clone CodePair repository with the following command:
 $ git clone https://github.com/yorkie-team/codepair
 ```
 
-Then, change directory to codepair folder and install dependencies with the following command:
+Then, navigate to the frontend folder in the CodePair repository and change `VITE_YORKIE_API_ADDR` in `.env.development` file to API Domain of Yorkie cluster you have configured above.
 
 ```bash
-$ cd codepair
-$ npm install
-```
-
-After dependencies are installed, change `VITE_APP_YORKIE_RPC_ADDR` in `.env.development` file to API Domain of Yorkie cluster you have configured above.
-
-```bash
+$ cd codepair/frontend
 $ vi .env.development
 
-VITE_APP_YORKIE_RPC_ADDR=http://{YOUR_API_DOMAIN_NAME}
+VITE_YORKIE_API_ADDR=http://{YOUR_API_DOMAIN_NAME}
 ```
-
-Then, start CodePair with the following command:
-
-```bash
-$ npm run dev
-
-> codepair@1.0.0 dev
-> vite --config ./config/vite.config.development.ts
-
-
-  VITE v4.3.0  ready in 257 ms
-
-  ➜  Local:   http://localhost:3000/
-  ➜  Network: use --host to expose
-  ➜  press h to show help
-```
-
-You can open several web browsers and access `http://localhost:3000` to test collaborative editing with CodePair.
+To continue with the setup, follow the detailed instructions in the [README](https://github.com/yorkie-team/codepair/blob/main/README.md).
 
 ### Clean up Yorkie cluster
 

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -235,42 +235,20 @@ Clone CodePair repository with the following command:
 $ git clone https://github.com/yorkie-team/codepair
 ```
 
-Then, change directory to codepair folder and install dependencies with the following command:
+Then, navigate to the frontend folder in the CodePair repository and change `VITE_YORKIE_API_ADDR` in `.env.development` file to your minikube IP address.
 
 ```bash
-$ cd codepair
-$ npm install
-```
-
-After dependencies are installed, change `VITE_APP_YORKIE_RPC_ADDR` in `.env.development` file to your minikube IP address.
-
-```bash
+$ cd codepair/frontend
 $ vi .env.development
 
-VITE_APP_YORKIE_RPC_ADDR=http://<minikube-ip>
-# If you are using macOS, you should set VITE_APP_YORKIE_RPC_ADDR to localhost instead of minikube-ip.
-# VITE_APP_YORKIE_RPC_ADDR=http://localhost
+VITE_YORKIE_API_ADDR=http://<minikube-ip>
+# If you are using macOS, you should set VITE_YORKIE_API_ADDR to localhost instead of minikube-ip.
+# VITE_YORKIE_API_ADDR=http://localhost
 ```
 
-<Alert status="warning">If you are using macOS, you should set `VITE_APP_YORKIE_RPC_ADDR` to `localhost` instead of `minikube ip`.</Alert>
+<Alert status="warning">If you are using macOS, you should set `VITE_YORKIE_API_ADDR` to `localhost` instead of `minikube ip`.</Alert>
 
-Then, start CodePair with the following command:
-
-```bash
-$ npm run dev
-
-> codepair@1.0.0 dev
-> vite --config ./config/vite.config.development.ts
-
-
-  VITE v4.3.0  ready in 257 ms
-
-  ➜  Local:   http://localhost:3000/
-  ➜  Network: use --host to expose
-  ➜  press h to show help
-```
-
-You can open several web browsers and access `http://localhost:3000` to test collaborative editing with CodePair.
+To continue with the setup, follow the detailed instructions in the [README](https://github.com/yorkie-team/codepair/blob/main/README.md).
 
 ### Clean up Yorkie cluster
 
@@ -304,7 +282,7 @@ Use `Ctrl + C` to stop minikube tunnel.
 Password:
 
 # Stop minikube tunnel
-$ 
+$ ^C
 
 ✋  Stopped tunnel for service yorkie.
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR modifies the documentation to update the environment variable name from `VITE_APP_YORKIE_RPC_ADDR` to `VITE_YORKIE_API_ADDR` and reference the `README` for CodePair setup.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions for the CodePair repository, emphasizing navigation to the `frontend` folder.
  - Clarified naming convention by changing `VITE_APP_YORKIE_RPC_ADDR` to `VITE_YORKIE_API_ADDR`.
  - Streamlined setup process by consolidating command instructions to refer to the README for further guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->