### PR TITLE
Fix type error in `document.subscribe('status')`

### DIFF
--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -340,13 +340,13 @@ For more information about `DocumentSyncStatus`, please refer to the [DocumentSy
 
 ##### Document.subscribe('status')
 
-You can subscribe to the status of the document using `doc.subscribe('status', callback)`. The possible values for `event.value` are `DocumentStatus.Attached` and `DocumentStatus.Detached`.
+You can subscribe to the status of the document using `doc.subscribe('status', callback)`. The possible values for `event.value.status` are `DocumentStatus.Attached` and `DocumentStatus.Detached`.
 
 ```javascript
 const unsubscribe = doc.subscribe('status', (event) => {
-  if (event.value === DocumentStatus.Attached) {
+  if (event.value.status === DocumentStatus.Attached) {
     // The document is attached to the client.
-  } else if (event.value === DocumentStatus.Detached) {
+  } else if (event.value.status === DocumentStatus.Detached) {
     // The document is detached from the client.
   }
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

There is a typo in the `document.subscribe('status')` documentation. We should compare `event.value.status` with either `DocumentStatus.Attached` or `DocumentStatus.Detached`.

#### Any background context you want to provide?
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/7c0ede40-ae48-4dda-ad33-7550800627f5">



#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity around document status updates in the subscription callback for better understanding.
  
- **Bug Fixes**
	- Corrected logic for evaluating document status, ensuring accurate status reporting as either attached or detached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->