### PR TITLE
Updated minikube cluster deployment documentation

### DIFF
--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -8,7 +8,7 @@ order: 81
 Minikube is a tool that makes it easy to run Kubernetes locally.
 
 In this guide, you will install Yorkie cluster on minikube using Helm.
-Then, you will test Yorkie cluster with CodePair, a collaborative code editor.
+Then, you will test Yorkie cluster with Quill, a collaborative code editor example.
 
 ### Prerequisites
 
@@ -184,11 +184,11 @@ $ kubectl get pods -n yorkie --watch
 After all pods are ready, you will see the following output:
 
 ```
-NAME                      READY   STATUS    RESTARTS      AGE
-mongodb-0                 1/1     Running   0             76s
-yorkie-74969cc796-46s47   1/1     Running   2 (54s ago)   76s
-yorkie-74969cc796-c8zpt   1/1     Running   2 (50s ago)   76s
-yorkie-74969cc796-n9jtr   1/1     Running   2 (52s ago)   76s
+NAME                             READY   STATUS    RESTARTS   AGE
+yorkie-f595554db-48s9c           1/1     Running   0          8m18s
+yorkie-f595554db-nggr9           1/1     Running   0          8m18s
+yorkie-f595554db-z5jgs           1/1     Running   0          8m18s
+yorkie-gateway-844d8c87d-fqpsk   1/1     Running   0          9m55s
 ```
 
 ### Expose Yorkie cluster with Minikube tunnel
@@ -227,73 +227,81 @@ $ minikube ip
 
 ### Test Yorkie cluster
 
-Now that you have Yorkie cluster installed and exposed, you can test Yorkie cluster with [CodePair](https://github.com/yorkie-team/codepair), a collaborative editing tool powered by Yorkie.
+Now that you have Yorkie cluster installed and exposed, you can test Yorkie cluster with [yorkie-js-sdk](https://github.com/yorkie-team/yorkie-js-sdk), an SDK for developing collaborative tools powered by Yorkie
 
-Clone CodePair repository with the following command:
+Clone yorkie-js-sdk repository with the following command:
 
 ```bash
-$ git clone https://github.com/yorkie-team/codepair
+$ git clone https://github.com/yorkie-team/yorkie-js-sdk
 ```
 
-Then, change directory to codepair folder and install dependencies with the following command:
+Then, change directory to yorkie-js-sdk folder and install dependencies with the following command:
 
 ```bash
-$ cd codepair
-$ npm install
+$ cd yorkie-js-sdk
+$ pnpm i
 ```
 
-After dependencies are installed, change `VITE_APP_YORKIE_RPC_ADDR` in `.env.development` file to your minikube IP address.
+Then, to use Quill, a simple text editing example, navigate to the examples/vanilla-quill folder in the yorkie-js-sdk repository and change `VITE_YORKIE_API_ADDR` in the `.env` file to your minikube IP address.
 
 ```bash
-$ vi .env.development
+$ cd examples/vanilla-quill
+$ vi .env
 
-VITE_APP_YORKIE_RPC_ADDR=http://<minikube-ip>
-# If you are using macOS, you should set VITE_APP_YORKIE_RPC_ADDR to localhost instead of minikube-ip.
-# VITE_APP_YORKIE_RPC_ADDR=http://localhost
+VITE_YORKIE_API_ADDR=http://<minikube-ip>
+# If you are using macOS, you should set VITE_YORKIE_API_ADDR to localhost instead of minikube-ip.
+# VITE_YORKIE_API_ADDR=http://localhost
 ```
 
-<Alert status="warning">If you are using macOS, you should set `VITE_APP_YORKIE_RPC_ADDR` to `localhost` instead of `minikube ip`.</Alert>
+<Alert status="warning">If you are using macOS, you should set `VITE_YORKIE_API_ADDR` to `localhost` instead of `minikube ip`.</Alert>
 
-Then, start CodePair with the following command:
+Then, start Quill with the following command:
 
 ```bash
-$ npm run dev
+$ cd ../..
+$ pnpm vanilla-quill dev
 
-> codepair@1.0.0 dev
-> vite --config ./config/vite.config.development.ts
+> yorkie-js@0.0.0 vanilla-quill /yorkie-js-sdk
+> pnpm --filter=vanilla-quill "dev"
 
 
-  VITE v4.3.0  ready in 257 ms
+> vanilla-quill@0.0.0 dev /yorkie-js-sdk/examples/vanilla-quill
+> vite
 
-  ➜  Local:   http://localhost:3000/
+
+  VITE v5.3.5  ready in 178 ms
+
+  ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose
-  ➜  press h to show help
+  ➜  press h + enter to show help
 ```
 
-You can open several web browsers and access `http://localhost:3000` to test collaborative editing with CodePair.
+You can open several web browsers and access `http://localhost:5173` to test collaborative editing with Quill.
+
+For more examples of collaborative tools developed with Yorkie, including Quill, take a look at [yorkie-js-sdk examples](https://github.com/yorkie-team/yorkie-js-sdk/tree/main/examples#examples).
 
 ### Clean up Yorkie cluster
 
-You have now installed Yorkie cluster on your local machine, and tested collaborative editing with CodePair.
+You have now installed Yorkie cluster on your local machine, and tested collaborative editing with Quill.
 
 <Alert status="info">To learn about how to configure Yorkie Cluster in Helm Chart, see [Yorkie Cluster Helm Chart Repository](https://github.com/yorkie-team/yorkie/tree/main/build/charts/yorkie-cluster).</Alert>
 
-First, stop CodePair and remove repository folder with the following command:
-Use `Ctrl + C` to stop CodePair.
+First, stop Quill and remove repository folder with the following command:
+Use `Ctrl + C` to stop Quill.
 
 ```bash
-VITE v4.3.0  ready in 257 ms
+  VITE v5.3.5  ready in 178 ms
 
-➜  Local:   http://localhost:3000/
-➜  Network: use --host to expose
-➜  press h to show help
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+  ➜  press h + enter to show help
 
-# Stop CodePair
+# Stop Quill
 $ ^C
 
 # Remove repository folder
 $ cd ..
-$ rm -rf codepair
+$ rm -rf yorkie-js-sdk
 ```
 
 Then, stop minikube tunnel in running terminal.
@@ -304,7 +312,7 @@ Use `Ctrl + C` to stop minikube tunnel.
 Password:
 
 # Stop minikube tunnel
-$ 
+$ ^C
 
 ✋  Stopped tunnel for service yorkie.
 ```

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -8,7 +8,7 @@ order: 81
 Minikube is a tool that makes it easy to run Kubernetes locally.
 
 In this guide, you will install Yorkie cluster on minikube using Helm.
-Then, you will test Yorkie cluster with Quill, a collaborative code editor example.
+Then, you will test Yorkie cluster with Quill Example to see how collaborative editing works with Yorkie.
 
 ### Prerequisites
 
@@ -227,7 +227,7 @@ $ minikube ip
 
 ### Test Yorkie cluster
 
-Now that you have Yorkie cluster installed and exposed, you can test Yorkie cluster with [yorkie-js-sdk](https://github.com/yorkie-team/yorkie-js-sdk), an SDK for developing collaborative tools powered by Yorkie
+Now that you have Yorkie cluster installed and exposed, you can test Yorkie cluster with [yorkie-js-sdk](https://github.com/yorkie-team/yorkie-js-sdk), a JavaScript SDK for Yorkie.
 
 Clone yorkie-js-sdk repository with the following command:
 
@@ -242,7 +242,7 @@ $ cd yorkie-js-sdk
 $ pnpm i
 ```
 
-Then, to use Quill, a simple text editing example, navigate to the examples/vanilla-quill folder in the yorkie-js-sdk repository and change `VITE_YORKIE_API_ADDR` in the `.env` file to your minikube IP address.
+After dependencies are installed, you need to set `VITE_YORKIE_API_ADDR` in the `.env` file to your minikube IP address with the following command:
 
 ```bash
 $ cd examples/vanilla-quill
@@ -255,7 +255,7 @@ VITE_YORKIE_API_ADDR=http://<minikube-ip>
 
 <Alert status="warning">If you are using macOS, you should set `VITE_YORKIE_API_ADDR` to `localhost` instead of `minikube ip`.</Alert>
 
-Then, start Quill with the following command:
+Then, start Quill Example with the following command:
 
 ```bash
 $ cd ../..
@@ -286,8 +286,8 @@ You have now installed Yorkie cluster on your local machine, and tested collabor
 
 <Alert status="info">To learn about how to configure Yorkie Cluster in Helm Chart, see [Yorkie Cluster Helm Chart Repository](https://github.com/yorkie-team/yorkie/tree/main/build/charts/yorkie-cluster).</Alert>
 
-First, stop Quill and remove repository folder with the following command:
-Use `Ctrl + C` to stop Quill.
+First, stop Quill Example and remove repository folder with the following command:
+Use `Ctrl + C` to stop Quill Example.
 
 ```bash
   VITE v5.3.5  ready in 178 ms


### PR DESCRIPTION
Modify the content of existing documentation that differs from the current yorkie version Changed examples for testing yorkie cluster from CodePair to Quill in the yorkie-js-sdk

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
The docs for building a yorkie cluster with minikube are expired or missing.
This PR starts by fixing those, and then moves to the Quill example in the yorkie-js-sdk instead of the Code Pair example, which is too heavy for testing clusters.

#### Any background context you want to provide?
The dependencies for minikube, helm, and istio are specified, but I'm wondering if it's right to not specify the dependencies for npm, pnpm, etc. to run the yorkie-js-sdk.
- Pros of specifying: smoother testing
- Cons of specification: this documentation is more focused on the core topic of Yorkie Cluster

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #156 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated installation and testing documentation for the Yorkie cluster on Minikube.
	- Replaced references from "CodePair" to "Quill" for clarity on the collaborative code editor.
	- Revised commands and environment variable configurations to reflect updates for Quill.
	- Enhanced accuracy in output messages related to starting the collaborative tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->