### PR TITLE
Update Docs: AWS EKS doc

### DIFF
--- a/docs/self-hosted-server/aws-eks.mdx
+++ b/docs/self-hosted-server/aws-eks.mdx
@@ -8,7 +8,7 @@ order: 82
 AWS's Elastic Kubernetes Service (EKS) is a managed service that lets you deploy, manage, and scale containerized applications on Kubernetes.
 
 In this guide, you will install Yorkie cluster on AWS EKS using Helm.
-Then, you will test Yorkie cluster with CodePair, a collaborative code editor.
+Then, you will test Yorkie cluster with Quill Example to see how collaborative editing works with Yorkie.
 
 <Alert status="danger">[AWS EKS clusters cost $0.10 per hour](https://aws.amazon.com/eks/pricing/), so you may incur charges by running this tutorial. The cost should be a few dollars at most, but be sure to delete your infrastructure promptly to avoid additional charges. We are not responsible for any charges you may incur.</Alert>
 
@@ -159,11 +159,11 @@ $ kubectl get pods -n yorkie --watch
 After all pods are ready, you will see the following output:
 
 ```
-NAME                      READY   STATUS    RESTARTS      AGE
-mongodb-0                 1/1     Running   0             76s
-yorkie-74969cc796-46s47   1/1     Running   2 (54s ago)   76s
-yorkie-74969cc796-c8zpt   1/1     Running   2 (50s ago)   76s
-yorkie-74969cc796-n9jtr   1/1     Running   2 (52s ago)   76s
+NAME                             READY   STATUS    RESTARTS   AGE
+yorkie-f595554db-48s9c           1/1     Running   0          8m18s
+yorkie-f595554db-nggr9           1/1     Running   0          8m18s
+yorkie-f595554db-z5jgs           1/1     Running   0          8m18s
+yorkie-gateway-844d8c87d-fqpsk   1/1     Running   0          9m55s
 ```
 
 ### Test Yorkie cluster
@@ -220,7 +220,7 @@ For more examples of collaborative tools developed with Yorkie, including Quill,
 
 ### Clean up Yorkie cluster
 
-You have now installed Yorkie cluster in AWS EKS, and tested collaborative editing with CodePair.
+You have now installed Yorkie cluster in AWS EKS, and tested collaborative editing with Quill.
 
 <Alert status="info">To learn about how to configure Yorkie Cluster in Helm Chart, see [Yorkie Cluster Helm Chart Repository](https://github.com/yorkie-team/yorkie/tree/main/build/charts/yorkie-cluster).</Alert>
 

--- a/docs/self-hosted-server/aws-eks.mdx
+++ b/docs/self-hosted-server/aws-eks.mdx
@@ -107,8 +107,8 @@ $ helm install yorkie-cluster yorkie-team/yorkie-cluster \
 	--set ingress.ingressClassName=alb \
 	--set ingress.hosts.enabled=true \
     --set ingress.hosts.apiHost={YOUR_API_DOMAIN_NAME} \
-    --set ingress.alb.enabled=true \
-    --set ingress.alb.certArn={YOUR_CERTIFICATE_ARN}
+    --set ingress.awsAlb.enabled=true \
+    --set ingress.awsAlb.certArn={YOUR_CERTIFICATE_ARN}
 
 # For example, for domain name `yorkie.dev` and certificate ARN 
 # `arn:aws:acm:ap-northeast-2:123412341234:certificate/12341234-1234-1234-1234-123412341234`, run the following command:
@@ -116,8 +116,8 @@ $ helm install yorkie-cluster yorkie-team/yorkie-cluster \
 	--set ingress.ingressClassName=alb \
 	--set ingress.hosts.enabled=true \
     --set ingress.hosts.apiHost=api.yorkie.dev \
-    --set ingress.alb.enabled=true \
-    --set ingress.alb.certArn=arn:aws:acm:ap-northeast-2:123412341234:certificate/12341234-1234-1234-1234-123412341234
+    --set ingress.awsAlb.enabled=true \
+    --set ingress.awsAlb.certArn=arn:aws:acm:ap-northeast-2:123412341234:certificate/12341234-1234-1234-1234-123412341234
 ```
 
 Replace `{YOUR_API_DOMAIN_NAME}` with your domain name. Also, replace `{YOUR_CERTIFICATE_ARN}` with your certificate ARN.

--- a/docs/self-hosted-server/aws-eks.mdx
+++ b/docs/self-hosted-server/aws-eks.mdx
@@ -168,46 +168,55 @@ yorkie-74969cc796-n9jtr   1/1     Running   2 (52s ago)   76s
 
 ### Test Yorkie cluster
 
-Now that you have Yorkie cluster installed and exposed, you can test Yorkie cluster with [CodePair](https://github.com/yorkie-team/codepair), a collaborative editing tool powered by Yorkie.
+Now that you have Yorkie cluster installed and exposed, you can test Yorkie cluster with [yorkie-js-sdk](https://github.com/yorkie-team/yorkie-js-sdk), a JavaScript SDK for Yorkie.
 
-Clone CodePair repository with the following command:
+Clone yorkie-js-sdk repository with the following command:
 
 ```bash
-$ git clone https://github.com/yorkie-team/codepair
+$ git clone https://github.com/yorkie-team/yorkie-js-sdk
 ```
 
-Then, change directory to codepair folder and install dependencies with the following command:
+Then, change directory to yorkie-js-sdk folder and install dependencies with the following command:
 
 ```bash
-$ cd codepair
-$ npm install
+$ cd yorkie-js-sdk
+$ pnpm i
 ```
 
-After dependencies are installed, change `VITE_APP_YORKIE_RPC_ADDR` in `.env.development` file to API Domain of Yorkie cluster you have configured above.
+After dependencies are installed, you need to set `VITE_YORKIE_API_ADDR` in the `.env` file to your AWS api domain name or IP address with the following command:
 
 ```bash
-$ vi .env.development
+$ cd examples/vanilla-quill
+$ vi .env
 
-VITE_APP_YORKIE_RPC_ADDR=http://{YOUR_API_DOMAIN_NAME}
+VITE_YORKIE_API_ADDR=http://<YOUR_API_DOMAIN_NAME or IP_ADDRESS>
 ```
 
-Then, start CodePair with the following command:
+Then, start Quill Example with the following command:
 
 ```bash
-$ npm run dev
+$ cd ../..
+$ pnpm vanilla-quill dev
 
-> codepair@1.0.0 dev
-> vite --config ./config/vite.config.development.ts
+> yorkie-js@0.0.0 vanilla-quill /yorkie-js-sdk
+> pnpm --filter=vanilla-quill "dev"
 
 
-  VITE v4.3.0  ready in 257 ms
+> vanilla-quill@0.0.0 dev /yorkie-js-sdk/examples/vanilla-quill
+> vite
 
-  ➜  Local:   http://localhost:3000/
+
+  VITE v5.3.5  ready in 178 ms
+
+  ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose
-  ➜  press h to show help
+  ➜  press h + enter to show help
 ```
 
-You can open several web browsers and access `http://localhost:3000` to test collaborative editing with CodePair.
+You can open several web browsers and access `http://localhost:5173` to test collaborative editing with Quill.
+
+For more examples of collaborative tools developed with Yorkie, including Quill, take a look at [yorkie-js-sdk examples](https://github.com/yorkie-team/yorkie-js-sdk/tree/main/examples#examples).
+
 
 ### Clean up Yorkie cluster
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Modify the content of AWS EKS doc.
- Fix `ingress.alb` => `ingress.awsAlb` in the Helm cli command `--set`.
- Update yorkie test example with yorkie-js-sdk vanilla-quill instead of the CodePair.


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated references and commands for the Yorkie collaborative editing tool.
	- Clarified the tool used for demonstrations from "CodePair" to "Quill Example."
	- Revised Helm installation commands for AWS Application Load Balancer settings.
	- Adjusted environment variable naming and setup instructions.
	- Provided updated commands for cloning the repository and starting the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->