### PR TITLE
Add explanation for `initialRoot` usage in Documentation

### DIFF
--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -80,6 +80,29 @@ The initial values are partially applied. For each element in `initialRoot`:
 - If the key doesn't exist, the element will be applied.
 - If the key already exists in the Document, that element will be discarded. Users don't need to worry about overwriting existing valid counters.
 
+```javascript
+await client.attach(doc, {
+  initialRoot: {
+    list: [],
+  },
+});
+
+// Another client tries to attach with initialRoot option:
+await client.attach(doc, {
+  initialRoot: {
+    list: [1, 2, 3],    // this update will be discarded
+    counter: new yorkie.Counter(yorkie.IntType, 0), // this update will be applied
+  },
+});
+
+// final state
+// root = {
+//   list: [],
+//   counter: {}
+// }
+```
+
+We support element types for Primitives, and [Custom CRDT types](/js-sdk/#custom-crdt-types/).
 
 <Alert status="warning">
 Elements added by `initialRoot` are not sent to the server during the `attach` process. They are applied locally to the Document after push-pull during `attach`.

--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -63,6 +63,28 @@ await client.attach(doc, {
 });
 ```
 
+#### Initializing root
+
+The root is used to manage the application's data, such as primitives, arrays, Counters, and Text in a form within the `Document`. You can set the initial values when calling `Document.attach()` using the `initialRoot` option.
+
+```javascript
+await client.attach(doc, {
+  initialRoot: {
+    list: [1, 2, 3],
+    counter: new yorkie.Counter(yorkie.IntType, 0),
+  },
+});
+```
+
+The initial values are partially applied. For each element in `initialRoot`:
+- If the key doesn't exist, the element will be applied.
+- If the key already exists in the Document, that element will be discarded. Users don't need to worry about overwriting existing valid counters.
+
+
+<Alert status="warning">
+Elements added by `initialRoot` are not sent to the server during the `attach` process. They are applied locally to the Document after push-pull during `attach`.
+</Alert>
+
 #### Updating presence
 
 The `Document.update()` method allows you to make changes to the state of the current user's presence.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR adds documentation to describe the new feature that allows setting initial values when attaching a document. This functionality was introduced in [PR #986](https://github.com/yorkie-team/yorkie/pull/986), enabling developers to initialize documents with specific values upon attachment.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Yorkie JS SDK documentation with a new section on initializing the root of a Document, detailing management of application data types.
	- Clarified how initial values are applied based on existing keys and provided examples for better understanding.
	- Emphasized that elements added by `initialRoot` are applied locally and not sent to the server during the attach process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->