### PR TITLE
Move iOS and Android SDK to development phase

### DIFF
--- a/components/Layout/MobileGnbDropdown.tsx
+++ b/components/Layout/MobileGnbDropdown.tsx
@@ -87,26 +87,30 @@ export function MobileGnbDropdown({ isLoggedIn }: { isLoggedIn: boolean }) {
                       JS SDK
                     </Link>
                   </li>
-                  <li className="navigator_group">
-                    <Link
-                      href="/docs/ios-sdk"
-                      className={classNames('navigator_item', 'add_icon', {
-                        is_active: asPath.startsWith(`/docs/ios-sdk`),
-                      })}
-                    >
-                      iOS SDK
-                    </Link>
-                  </li>
-                  <li className="navigator_group">
-                    <Link
-                      href="/docs/android-sdk"
-                      className={classNames('navigator_item', 'add_icon', {
-                        is_active: asPath.startsWith(`/docs/android-sdk`),
-                      })}
-                    >
-                      Android SDK
-                    </Link>
-                  </li>
+                  {process.env.NODE_ENV === 'development' && (
+                    <>
+                      <li className="navigator_group">
+                        <Link
+                          href="/docs/ios-sdk"
+                          className={classNames('navigator_item', 'add_icon', {
+                            is_active: asPath.startsWith(`/docs/ios-sdk`),
+                          })}
+                        >
+                          iOS SDK
+                        </Link>
+                      </li>
+                      <li className="navigator_group">
+                        <Link
+                          href="/docs/android-sdk"
+                          className={classNames('navigator_item', 'add_icon', {
+                            is_active: asPath.startsWith(`/docs/android-sdk`),
+                          })}
+                        >
+                          Android SDK
+                        </Link>
+                      </li>
+                    </>
+                  )}
                   <li className="navigator_group">
                     <Link
                       href="/docs/devtools"

--- a/docs/android-sdk.mdx
+++ b/docs/android-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Android SDK'
 order: 50
+phase: development
 ---
 
 ## Android SDK

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -10,5 +10,7 @@ Welcome to Yorkie! In this guide, we will walk you through the steps to install 
 You can choose your preferred technology from the options below:
 
 - [with JS SDK](/docs/getting-started/with-js-sdk)
+
+iOS and Android SDKs are coming soon. Stay tuned!
 - [with iOS SDK](/docs/getting-started/with-ios-sdk)
 - [with Android SDK](/docs/getting-started/with-android-sdk)

--- a/docs/getting-started/with-android-sdk.mdx
+++ b/docs/getting-started/with-android-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'with Android SDK'
 order: 23
+phase: development
 ---
 
 ## Getting Started with Android SDK

--- a/docs/getting-started/with-ios-sdk.mdx
+++ b/docs/getting-started/with-ios-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'with iOS SDK'
 order: 22
+phase: development
 ---
 
 ## Getting Started with iOS SDK

--- a/docs/ios-sdk.mdx
+++ b/docs/ios-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'iOS SDK'
 order: 40
+phase: development
 ---
 
 ## iOS SDK


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Move iOS and Android SDK to development phase

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Conditional rendering of iOS and Android SDK documentation links in the mobile dropdown, now only visible in development mode.
	- Added informational note about forthcoming iOS and Android SDKs in the getting started documentation.

- **Documentation**
	- Introduced `phase: development` metadata in various SDK-related documents to categorize their current status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->