### PR TITLE
Prevent dark mode flash on page refresh

### DIFF
--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,30 +1,33 @@
 import { useState, useEffect } from 'react';
 
 export type ThemeOption = 'system' | 'light' | 'dark';
+const applyTheme = (theme: 'light' | 'dark') => {
+  if (theme === 'light') {
+    window.document.documentElement.classList.remove('darkmode');
+    window.document.documentElement.style.colorScheme = 'light';
+  } else {
+    window.document.documentElement.classList.add('darkmode');
+    window.document.documentElement.style.colorScheme = 'dark';
+  }
+};
 export function useTheme(initialTheme?: ThemeOption) {
   const [theme, setTheme] = useState<ThemeOption | undefined>(initialTheme);
 
   useEffect(() => {
     const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
     const handleSystemThemeChange = (e: MediaQueryListEvent) => {
-      if (e.matches) {
-        window.document.body.classList.add('darkmode');
-      } else {
-        window.document.body.classList.remove('darkmode');
-      }
+      applyTheme(e.matches ? 'dark' : 'light');
     };
 
     if (theme === 'dark') {
-      window.document.body.classList.add('darkmode');
+      applyTheme('dark');
       window.localStorage.setItem('theme', 'dark');
     } else if (theme === 'light') {
-      window.document.body.classList.remove('darkmode');
+      applyTheme('light');
       window.localStorage.setItem('theme', 'light');
     } else if (theme === 'system') {
       window.localStorage.setItem('theme', 'system');
-      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        window.document.body.classList.add('darkmode');
-      }
+      applyTheme(mediaQueryList.matches ? 'dark' : 'light');
       mediaQueryList.addEventListener('change', handleSystemThemeChange);
     }
     return () => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -37,21 +37,6 @@ function MyApp({ Component, pageProps }: AppProps) {
           content="Easily add collaboration to your apps with our API-based services."
         />
       </Head>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-            (function () {
-              const theme = window.localStorage.getItem('theme') || 'system';
-              const isDarkMode = theme === 'dark' ||
-                (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-              if (isDarkMode) {
-                window.document.documentElement.classList.add('darkmode');
-                window.document.documentElement.style.colorScheme = 'dark';
-              }
-            })();
-          `,
-        }}
-      />
       <Script src="https://www.googletagmanager.com/gtag/js?id=G-7KXWLDH8CH" strategy="afterInteractive" />
       <Script id="google-analytics" strategy="afterInteractive">
         {`

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -37,6 +37,21 @@ function MyApp({ Component, pageProps }: AppProps) {
           content="Easily add collaboration to your apps with our API-based services."
         />
       </Head>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+            (function () {
+              const theme = window.localStorage.getItem('theme') || 'system';
+              const isDarkMode = theme === 'dark' ||
+                (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+              if (isDarkMode) {
+                window.document.documentElement.classList.add('darkmode');
+                window.document.documentElement.style.colorScheme = 'dark';
+              }
+            })();
+          `,
+        }}
+      />
       <Script src="https://www.googletagmanager.com/gtag/js?id=G-7KXWLDH8CH" strategy="afterInteractive" />
       <Script id="google-analytics" strategy="afterInteractive">
         {`

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,27 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Script id="initial-theme" strategy="beforeInteractive">
+          {`
+            (function () {
+              const theme = window.localStorage.getItem('theme') || 'system';
+              const isDarkMode = theme === 'dark' ||
+                (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+              if (isDarkMode) {
+                window.document.documentElement.classList.add('darkmode');
+                window.document.documentElement.style.colorScheme = 'dark';
+              }
+            })();
+          `}
+        </Script>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/styles/base/_common.scss
+++ b/styles/base/_common.scss
@@ -129,6 +129,10 @@ a {
   @extend %visuallyhidden;
 }
 
+html {
+  background-color: var(--gray-000);
+}
+
 // color
 $palette: (
   'gray': (


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR fixes the white flash that appears when refreshing the page in dark mode. 
To solve this, we now apply dark mode styles earlier in the page load process (before First Paint), so users won't see any unwanted white flashes when refreshing.

before | after |
:--: | :--: |
![homepage-fouc](https://github.com/user-attachments/assets/f1110a1e-f2e1-4da9-bd3a-e5719e9ad16b)|![hoempage-fix](https://github.com/user-attachments/assets/59b218d7-b4e5-4b98-8ea5-e1005319fbbf)


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced theme handling with improved theme application logic
	- Added immediate theme detection on page load based on user preferences

- **Style Changes**
	- Set default HTML background color to a light gray

- **Refactor**
	- Centralized theme application logic in a new `applyTheme` function
	- Improved theme switching mechanism across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->