### PR TITLE
Add document limits section to JS SDK documentation

### DIFF
--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -563,6 +563,52 @@ If the document is no longer used, it should be detached to increase the efficie
 await client.detach(doc);
 ```
 
+### Document Limits
+
+Yorkie enforces certain limits on document operations to ensure system stability and optimal performance. These limits can be configured through the Yorkie Dashboard's Project Settings.
+
+<Alert status="info">
+When you modify limit settings in the dashboard, the changes may take up to 10 minutes to be applied across all servers due to caching. During this period, different servers might temporarily have different limit values.
+</Alert>
+
+
+#### Max Attachments per Document
+When you attach a document, the server keeps track of the number of clients subscribed to it. The `Max Attachments per Document` setting determines how many clients can be attached to a single document simultaneously. If a client attempts to attach when this limit is reached, the server will reject the attachment with an error.
+
+If the attachment fails due to the limit, the client will need to retry the attachment by either reloading the SDK or calling `attach` again, as there is no automatic retry mechanism. 
+
+<Alert status="warning">
+In cases where clients terminate abnormally (browser crashes or network issues etc.), their attachments may remain until the server's housekeeping process removes them.
+
+To properly handle client termination and cleanup of document attachment resources, you can add an event listener to the page.
+
+```javascript
+window.addEventListener('beforeunload', () => {
+  client.deactivate({keepalive: true});
+  // or for detaching specific documents
+  // client.detach(doc, {keepalive: true});
+});
+```
+</Alert>
+
+#### Max Subscribers per Document
+When a client attaches to a document, it creates a subscription stream to receive real-time updates. The `Max Subscribers per Document` setting determines how many clients can maintain subscription streams simultaneously for a single document. If a client attempts to create a subscription stream when this limit is reached, the server will reject the request.
+
+Unlike attachment limits, the SDK automatically handles subscription limit errors by retrying the connection (1 retry per second).
+
+<Alert status="info">
+When the subscription limit is exceeded, you can monitor the connection status through the `Document.subscribe('connection')` callback. The SDK will receive a `StreamConnectionStatus.Disconnected` event, indicating that the watch stream is disconnected.
+
+```javascript
+doc.subscribe('connection', (event) => {
+  if (event.value === StreamConnectionStatus.Disconnected) {
+    // The connection is disconnected due to subscription limit or other issues
+    console.log('Watch stream disconnected, retrying automatically...');
+  }
+});
+```
+</Alert>
+
 ### Custom CRDT types
 
 Custom CRDT types are data types that can be used for special applications such as text editors and counters, unlike general JSON data types such as `Object` and `Array`. Custom CRDT types can be created in the callback function of `document.update`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Add document limits section to JS SDK documentation

#### Any background context you want to provide?

https://github.com/yorkie-team/yorkie/pull/1178
https://github.com/yorkie-team/yorkie/pull/1196

https://github.com/yorkie-team/yorkie-js-sdk/pull/952
https://github.com/yorkie-team/yorkie-js-sdk/pull/955

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a new "Document Limits" section that details operational thresholds.
  - Outlines limits for maximum attachments and subscription streams, including recommendations for error handling and retry mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->