### PR TITLE
Add --client flag to example script in CLI documentation

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -21,7 +21,7 @@ The easiest way to install Yorkie is from pre-built binaries:
 4. Test if Yorkie is in your PATH in shell:
 
 ```bash
-$ yorkie version
+$ yorkie version --client
 Yorkie: {{YORKIE_VERSION}}
 Commit: ...
 Go: ...


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Currently the `yorkie version` command tries to connect to a server by default. But we only need to check that the yorkie binary is downloaded correctly. Adding the `--client` flag prevents the command from looking for a server and avoids confusing readers who follow the guide.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #216

### Checklist
- [X] Added relevant tests or not required
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI installation guide to use the command `yorkie version --client` when verifying Yorkie is in the PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->