### PR TITLE
Update --enable-pprof flag to example script in CLI documentation

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -85,7 +85,7 @@ Flags:
       --backend-use-default-project                     Whether to use the default project. Even if public key is not provided from the client, the default project will be used for the request. (default true)
       --client-deactivate-threshold string              Deactivate threshold of clients in specific project for housekeeping. (default "24h")
   -c, --config string                                   Config path
-      --enable-pprof                                    Enable runtime profiling data via HTTP server.
+      --pprof-enabled                                   Enable runtime profiling data via HTTP server.
       --etcd-dial-timeout duration                      ETCD's dial timeout (default 5s)
       --etcd-endpoints strings                          Comma separated list of etcd endpoints
       --etcd-lock-lease-time duration                   ETCD's lease time for lock (default 30s)


### PR DESCRIPTION
<div align="center">
  <table>
    <tr>
      <th>Deprecated docs</th>
    </tr>
    <tr>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/c7a93c71-1b44-4071-9eb4-c92e656ef557" />
      </td>
    </tr>
  </table>
</div>

[> Docs](https://yorkie.dev/docs/cli#commands)

#### What this PR does / why we need it
 Update CLI reference and Docker Compose example to use the new --pprof-enabled flag rather than the deprecated --enable-pprof

- Swap deprecated `--enable-pprof` for new `--pprof-enabled`

#### Any background context you want to provide?
- Upstream CLI flag changed in yorkie-team/yorkie#1364

#### What are the relevant tickets?
Fixes #222 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI help text to rename the runtime profiling flag from `--enable-pprof` to `--pprof-enabled`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->