### PR TITLE
add API key acquisition guide to React SDK documentation

### DIFF
--- a/docs/getting-started/with-react.mdx
+++ b/docs/getting-started/with-react.mdx
@@ -49,6 +49,8 @@ function App() {
 }
 ```
 
+> The API key is used to identify the project in Yorkie. You can get the API key of the project you created in the [Dashboard]({{DASHBOARD_PATH}}).
+
 #### Accessing Document Data
 
 Use `useDocument`, `useRoot`, or `usePresences` hooks inside components to interact with the shared document.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

I checked the React SDK docs but couldn't find information on how to obtain an API key. I found the guide in the JS SDK documentation, so I simply added it to the React SDK docs as well for better discoverability.

#### Any background context you want to provide?
none

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note clarifying the use and source of the API key when setting up Yorkie with React.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->