### PR TITLE
Document useConnection hook in React SDK documentation

### DIFF
--- a/docs/getting-started/with-react.mdx
+++ b/docs/getting-started/with-react.mdx
@@ -49,6 +49,8 @@ function App() {
 }
 ```
 
+> The API key is used to identify the project in Yorkie. You can get the API key of the project you created in the [Dashboard]({{DASHBOARD_PATH}}).
+
 #### Accessing Document Data
 
 Use `useDocument`, `useRoot`, or `usePresences` hooks inside components to interact with the shared document.

--- a/docs/getting-started/with-react.mdx
+++ b/docs/getting-started/with-react.mdx
@@ -53,7 +53,7 @@ function App() {
 
 #### Accessing Document Data
 
-Use `useDocument`, `useRoot`, or `usePresences` hooks inside components to interact with the shared document.
+Use `useDocument`, `useRoot`, `usePresences`, or `useConnection` hooks inside components to interact with the shared document.
 
 ##### useDocument
 
@@ -132,6 +132,21 @@ function PresenceList() {
   );
 }
 ```
+
+##### useConnection
+
+To get the connection status of the document:
+
+```tsx
+import { useConnection } from '@yorkie-js/react';
+
+function ConnectionStatus() {
+  // "connected" or "disconnected"
+  const connection = useConnection();
+  return <p>Connection Status: {connection}</p>;
+}
+```
+
 
 ### Alternative Hook: useYorkieDoc
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
useConnection hook exists in React SDK, but is not documented.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie-js-sdk/issues/1043

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React integration guide to include the `useConnection` hook.
  * Added a new section with usage instructions and an example for displaying document connection status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->