### PR TITLE
Fix React useYorkieDoc example code in document

### DIFF
--- a/docs/getting-started/with-react.mdx
+++ b/docs/getting-started/with-react.mdx
@@ -159,7 +159,7 @@ function StandaloneTodoList() {
   const { root, update, loading, error } = useYorkieDoc(
     'PROJECT_API_KEY',
     'DOC_KEY',
-    { todos: [] }
+    { initialRoot: { todos: [] } }
   );
 
   if (loading) return <p>Loading...</p>;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
The current documentation example for `useYorkieDoc` is incorrect. The hook requires an `initialRoot` parameter, but the documentation shows passing `todos` directly as an argument. This PR fix it.

#### Any background context you want to provide?
None

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example usage of the `useYorkieDoc` hook to clarify how to specify the initial document root state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->