### PR TITLE
Remove prefixing `$` characters when copying code block

### DIFF
--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -1,4 +1,5 @@
 import { useClipboard } from 'hooks';
+import { cleanCliValue } from '@/utils/clipboardUtils';
 
 export function CopyButton({
   children,
@@ -10,7 +11,10 @@ export function CopyButton({
   value: string;
 }) {
   const clipboard = useClipboard({ timeout });
-  const copy = () => clipboard.copy(value);
+  const copy = () => {
+    const cleanedValue = cleanCliValue(value);
+    clipboard.copy(cleanedValue);
+  };
 
   return <>{children({ copy, copied: clipboard.copied })}</>;
 }

--- a/utils/clipboardUtils.ts
+++ b/utils/clipboardUtils.ts
@@ -1,0 +1,13 @@
+export function cleanCliValue(value: string): string {
+  const lines = value.split('\n');
+  
+  return lines
+    .map(line => {
+      // Remove $ prefix (dollar sign followed by space) commonly used in CLI documentation
+      if (line.startsWith('$ ')) {
+        return line.substring(2);
+      }
+      return line;
+    })
+    .join('\n');
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This enhancement improves the user experience when copying CLI commands from code blocks by automatically removing shell prompt indicators.

Previously, when users clicked the copy button on code blocks containing CLI commands like `$ npm install @yorkie-js/sdk`, the copied text would include the `$ ` prefix, requiring manual cleanup before pasting into a terminal.

Changes:
- Add cleanCliValue utility function to strip `$ ` prefixes from text
- Update CopyButton component to use the cleaning function
- Handle both single-line and multi-line code blocks
- Preserve lines that don't have CLI prefixes
- Only remove `$ ` (dollar + space) to avoid affecting other uses of $

This streamlines the workflow for users who frequently copy CLI commands from the documentation to run in their terminals.

![yorkie-team-149](https://github.com/user-attachments/assets/e8e9fcce-26d5-4918-accd-9e6f1572ac78)

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #149 

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Copy button now sanitizes copied text by removing leading "$ " prompts from each line, ensuring clean, ready-to-paste commands. No UI changes; only copied content behavior improved. Works across multi-line snippets, preserving line breaks and leaving non-prompt lines unchanged. This prevents accidental inclusion of shell prompt characters when pasting into terminals or scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->