### PR TITLE
Fix broken links and update enum references

### DIFF
--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -113,8 +113,8 @@ export function Footer({ shortFooter }: { shortFooter?: boolean }): ReactElement
           </div>
           <div className="site">
             <strong className="title">
-              <Link href="/support" className="link">
-                Support
+              <Link href="/community" className="link">
+                Community
               </Link>
             </strong>
             <ul className="site_list">

--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -414,35 +414,37 @@ For more information about `StreamConnectionStatus`, please refer to the [Stream
 ##### Document.subscribe('sync')
 
 If the document is attached to the client in `SyncMode.Realtime`, the document is automatically synchronized with the server in real-time.
-Under this mode, the document executes synchronization in the background, and you can track the synchronization status using the `sync` event. The possible `event.value` values are: `DocumentSyncStatus.Synced` and `DocumentSyncStatus.SyncFailed`.
+Under this mode, the document executes synchronization in the background, and you can track the synchronization status using the `sync` event. The possible `event.value` values are: `DocSyncStatus.Synced` and `DocSyncStatus.SyncFailed`.
 
 ```javascript
 const unsubscribe = doc.subscribe('sync', (event) => {
-  if (event.value === DocumentSyncStatus.Synced) {
+  if (event.value === DocSyncStatus.Synced) {
     // The document is synchronized with the server.
-  } else if (event.value === DocumentSyncStatus.SyncFailed) {
+  } else if (event.value === DocSyncStatus.SyncFailed) {
     // The document failed to synchronize with the server.
   }
 });
 ```
 
-For more information about `DocumentSyncStatus`, please refer to the [DocumentSyncStatus](https://yorkie.dev/yorkie-js-sdk/api-reference/enums/DocumentSyncStatus.html).
+For more information about `DocSyncStatus`, please refer to the [DocSyncStatus](https://yorkie.dev/yorkie-js-sdk/api-reference/enums/DocSyncStatus.html).
 
 ##### Document.subscribe('status')
 
-You can subscribe to the status of the document using `doc.subscribe('status', callback)`. The possible values for `event.value.status` are `DocumentStatus.Attached` and `DocumentStatus.Detached`.
+You can subscribe to the status of the document using `doc.subscribe('status', callback)`. The possible values for `event.value.status` are `DocStatus.Attached`, `DocStatus.Detached`, and `DocStatus.Removed`.
 
 ```javascript
 const unsubscribe = doc.subscribe('status', (event) => {
-  if (event.value.status === DocumentStatus.Attached) {
+  if (event.value.status === DocStatus.Attached) {
     // The document is attached to the client.
-  } else if (event.value.status === DocumentStatus.Detached) {
+  } else if (event.value.status === DocStatus.Detached) {
     // The document is detached from the client.
+  } else if (event.value.status === DocStatus.Removed) {
+    // The document is removed and cannot be edited
   }
 });
 ```
 
-For more information about `DocumentStatus`, please refer to the [DocumentStatus](https://yorkie.dev/yorkie-js-sdk/api-reference/enums/DocumentStatus.html).
+For more information about `DocStatus`, please refer to the [DocStatus](https://yorkie.dev/yorkie-js-sdk/api-reference/enums/DocStatus.html).
 
 <Alert status="warning">
 In Web-based applications, it is hard to detect when the user closes the browser or navigates to another page. In such cases, the document may remain attached to the client, which can lead to inefficient storage and memory usage.

--- a/pages/products.tsx
+++ b/pages/products.tsx
@@ -79,7 +79,7 @@ const Products: NextPage = () => {
           </div>
           <div className="section_content">
             <strong className="sub_title" id="flexible-database">
-              Document
+              <a href="#flexible-database">Document</a>
             </strong>
             <p className="sub_desc">
               Yorkie provides a general-purpose JSON-like{' '}
@@ -137,7 +137,7 @@ const Products: NextPage = () => {
             </strong>
             <p className="sub_desc">
               You can build a sense of presence by tracking the status of users who are editing the same document with{' '}
-              <Link href="/docs/js-sdk#presence" className="link">
+              <Link href="/docs/js-sdk#getting-presence" className="link">
                 Presence
               </Link>
               .


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Updated broken links and changed enum type references across page footer, JS SDK, and products documentation pages.

#### Any background context you want to provide?
None

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated JS SDK docs and samples to use DocSyncStatus and DocStatus (renamed from DocumentSyncStatus/DocumentStatus), added DocStatus.Removed, and updated reference links and status/subscription examples; added client-deactivate-threshold warning details.
  * Adjusted product page anchors and presence docs links for Document and Presence.

* **Style**
  * Footer: "Support" label changed to "Community" and link updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->