### PR TITLE
Add docs for Plain Object Conversion and Detachment Options

### DIFF
--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -323,6 +323,24 @@ console.log(root.obj.name); // "yorkie"
 console.log(root.counter.getValue()); // 1
 ```
 
+#### Converting Document Data to Plain JavaScript Objects
+
+You can convert Yorkie's JSONObject types to plain JavaScript objects using the `toJS()` method. This is useful when you need to serialize document data or integrate with other libraries that expect plain objects.
+
+```javascript
+const root = doc.getRoot();
+
+// Converting the entire root to a plain object
+const plainObject = root.toJS();
+console.log(plainObject); // Plain JavaScript object
+
+// Converting specific nested objects
+const plainTodos = root.todos.toJS();
+const plainObj = root.obj.toJS();
+```
+
+<Alert status="info"> The `toJS()` method creates a deep copy of the data as a plain JavaScript object, removing all Yorkie-specific metadata and proxies. </Alert>
+
 #### Subscribing to Document
 
 You can subscribe to various events occurring in the Document, such as changes, connection status, synchronization status, and all events by using the `document.subscribe()` method.
@@ -557,6 +575,19 @@ If the document is no longer used, it should be detached to increase the efficie
 ```javascript
 await client.detach(doc);
 ```
+
+When detaching a document, you can provide additional options to control the detachment behavior:
+
+```javascript
+await client.detach(doc, {
+  removeIfNotAttached: true
+});
+```
+
+Available options:
+- `removeIfNotAttached` (Optional, boolean): When set to true, the document will be completely removed from the server if no other clients are attached to it. This is useful for cleaning up temporary documents or sessions. Default is false.
+
+<Alert status="warning"> Use `removeIfNotAttached: true` carefully, as it will permanently delete the document from the server if no other clients are currently attached. This action cannot be undone. </Alert>
 
 ### Document Limits
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add docs for Plain Object Conversion and Detachment Options

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added guidance for converting document data to plain JavaScript objects, with examples for full documents and nested fields, and notes that conversion performs a deep copy and strips SDK metadata/proxies.
  * Documented detachment options, including removeIfNotAttached to fully remove a document when no other clients are attached, with a prominent warning about its irreversible effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->