### PR TITLE
Add Remove on Detach setting to documentation

### DIFF
--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -591,10 +591,10 @@ Available options:
 
 ##### Project-level Remove on Detach Setting
 
-The `Remove on Detach` setting is a project-level configuration that automatically applies the document removal behavior to all documents within the project, without requiring explicit `removeIfNotAttached: true` in individual detach calls.
+The `Remove on Detach` setting is a project-level configuration that enforces server-side removal when a detach leaves the document with zero attached clients. It automatically applies to all documents in the project; you don't need to pass `removeIfNotAttached: true` on individual detach calls.
 
 <Alert status="warning">
-When `Remove on Detach` setting is enabled, it takes precedence over any `removeIfNotAttached` values you might pass to individual `client.detach()` calls. Even if you explicitly set `removeIfNotAttached: false` in your code, documents will still be removed if no other clients are attached.
+When the `Remove on Detach` setting is enabled, it overrides any `removeIfNotAttached` value passed to `client.detach()`. Even if you set `removeIfNotAttached: false`, the server will remove the document once no other clients are attached at detach time.
 </Alert>
 
 ### Document Limits

--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -589,6 +589,14 @@ Available options:
 
 <Alert status="warning"> Use `removeIfNotAttached: true` carefully, as it will permanently delete the document from the server if no other clients are currently attached. This action cannot be undone. </Alert>
 
+##### Project-level Remove on Detach Setting
+
+The `Remove on Detach` setting is a project-level configuration that automatically applies the document removal behavior to all documents within the project, without requiring explicit `removeIfNotAttached: true` in individual detach calls.
+
+<Alert status="warning">
+When `Remove on Detach` setting is enabled, it takes precedence over any `removeIfNotAttached` values you might pass to individual `client.detach()` calls. Even if you explicitly set `removeIfNotAttached: false` in your code, documents will still be removed if no other clients are attached.
+</Alert>
+
 ### Document Limits
 
 Yorkie enforces certain limits on document operations to ensure system stability and optimal performance. These limits can be configured through the Yorkie Dashboard's Project Settings.
@@ -633,7 +641,6 @@ However, **remote updates are not subject to this limit** and are always applied
 
 Garbage-collected data is automatically reduced over time through system-managed garbage collection. While manual GC is not exposed, the system triggers GC under certain conditions. For instance, clients that remain inactive beyond the configured *Client Deactivate Threshold* are automatically deactivated, improving GC efficiency and reducing document GC size over time.  
 For details on GC and housekeeping, refer to the [housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/design/housekeeping.md).
-
 
 ### Custom CRDT types
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Add 'Remove on Detach' setting to documentation

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
- related to https://github.com/yorkie-team/yorkie/pull/1496

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two "Project-level Remove on Detach" sections to the JS SDK docs (under Available options and Detaching the Document).
  * Describes a project-wide setting that causes the server to remove documents when a detach leaves zero attached clients, without per-call removeIfNotAttached: true.
  * Clarifies the project-level setting overrides per-call removeIfNotAttached values.
  * No changes to the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->