### PR TITLE
Fix env var overriding issue and align SDK examples with setup

### DIFF
--- a/scripts/build-examples.mts
+++ b/scripts/build-examples.mts
@@ -96,6 +96,8 @@ const buildAllExamples = async () => {
         NODE_ENV: 'production',
       } as Record<string, string>;
 
+      createEnvFile(`${YORKIE_SDK_PATH}/examples/${name}`);
+
       if (name.startsWith('nextjs-')) {
         buildEnv.NEXT_PUBLIC_BASE_PATH = `/apps/${name}`;
         console.log(`Setting NEXT_PUBLIC_BASE_PATH=${buildEnv.NEXT_PUBLIC_BASE_PATH}`);

--- a/scripts/build-examples.mts
+++ b/scripts/build-examples.mts
@@ -3,9 +3,20 @@ import path from 'path';
 import { execSync } from 'child_process';
 import dotenv from 'dotenv';
 
-// Load environment variables
-dotenv.config({ path: '.env' });
-dotenv.config({ path: '.env.production', override: true });
+// Load environment variables with proper precedence:
+// 1. Command line variables (highest priority - already in process.env)
+// 2. Environment-specific file based on NODE_ENV
+// 3. .env (base defaults - lowest priority)
+
+const nodeEnv = process.env.NODE_ENV || 'development';
+
+// Load environment-specific file first (higher priority)
+if (nodeEnv === 'production') {
+  dotenv.config({ path: '.env.production', override: false });
+}
+
+// Load base .env file last (lower priority)
+dotenv.config({ path: '.env', override: false });
 
 const YORKIE_SDK_PATH = path.join(process.cwd(), 'temp');
 const EXAMPLES_OUTPUT_PATH = path.join(process.cwd(), 'public/apps');


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR addresses the issue of environment variables being overridden regardless of the values provided. Additionally, it ensures that each js-sdk example is correctly configured to utilize the appropriate environment variables based on the given setup.

#### Any background context you want to provide?

The previous implementation led to a situation where environment variables were not being respected, resulting in unexpected behavior across different environments. By rectifying this, we can ensure that the configurations are consistent and reliable, thus avoiding confusion during development and deployment.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored environment variable handling in the build system to establish clear precedence rules, ensuring command-line settings take priority over NODE_ENV-based configuration, which takes priority over default values.
  * Added automatic generation of per-example environment configuration files during the build process to ensure each example application is properly configured before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->