### PR TITLE
Reorganize docs into Tools & APIs, Configuration, and Internals groups

### DIFF
--- a/docs/advanced.mdx
+++ b/docs/advanced.mdx
@@ -1,23 +1,24 @@
 ---
-title: 'Advanced'
+title: 'Configuration'
 order: 110
 ---
 
-## Advanced
+## Configuration
 
-This section covers advanced topics for building production-ready applications with Yorkie. These guides are designed for users who are already familiar with basic Yorkie concepts and want to dive deeper into data formats, security configurations, and architectural patterns.
+This section covers configuration and integration topics for building production-ready applications with Yorkie. These guides help you design your architecture, secure your application, and configure project-level settings.
 
 ### Topics
 
 - **[Architecture Patterns](/docs/advanced/architecture-patterns)**: Explore recommended architectural patterns for integrating Yorkie with your existing systems
 - **[Security](/docs/advanced/security)**: Configure allowed origins and Auth Webhooks to secure your Yorkie applications
-- **[YSON](/docs/advanced/yson)**: Learn about Yorkie Structured Object Notation, the data format used to represent documents with specialized types for collaborative editing
+- **[Event Webhook](/docs/advanced/event-webhook)**: Receive notifications when specific events occur in your Yorkie documents
 - **[Revisions](/docs/advanced/revisions)**: Implement version control with snapshots, history browsing, and restore functionality
 - **[Resources](/docs/advanced/resources)**: Configure project-level settings for document limits, snapshots, and lifecycle behavior
+- **[Projects](/docs/advanced/projects)**: Organize multiple applications with project-based isolation, API keys, and per-project configuration
 
 ### Prerequisites
 
-Before exploring these advanced topics, ensure you have:
+Before exploring these topics, ensure you have:
 1. Completed the [Getting Started guide](/docs/getting-started)
 2. Built at least one application using Yorkie SDKs
 3. Understood basic concepts like [Client](/docs/js-sdk#client), [Document](/docs/js-sdk#document), and [Channel](/docs/js-sdk#channel)

--- a/docs/advanced/architecture-patterns.mdx
+++ b/docs/advanced/architecture-patterns.mdx
@@ -22,7 +22,7 @@ If you're new to Yorkie, we recommend:
 In this pattern, your existing database serves as the Source of Truth, while your server manages the document lifecycle through Yorkie's Admin API. This approach provides centralized control over document creation and deletion, making it suitable for applications that require strict server-side governance.
 
 **Key Characteristics:**
-- Server creates and deletes documents via [Admin API](/docs/admin-api#documents-management)
+- Server creates and deletes documents via [Admin API](/docs/tools/admin-api#documents-management)
 - Clients edit documents directly through Yorkie SDK during collaboration
 - Explicit "Save" action persists content to your database
 - Server maintains full control over document lifecycle
@@ -49,7 +49,7 @@ sequenceDiagram
 ```
 
 1. Client requests document creation from your server
-2. Server creates a new document through [Yorkie Admin API](/docs/admin-api#post-yorkiev1adminservicecreatedocument)
+2. Server creates a new document through [Yorkie Admin API](/docs/tools/admin-api#post-yorkiev1adminservicecreatedocument)
 3. Server stores document metadata in your database
 4. Server returns document key to client
 5. Client [attaches](/docs/js-sdk#attaching-the-document) to the document using the provided key
@@ -139,7 +139,7 @@ This pattern also uses your external database as the Source of Truth, but delega
 **Key Characteristics:**
 - Server only provides document keys and initial content
 - Clients create and manage documents independently
-- Automatic document cleanup via `RemoveOnDetach` project setting (configure via [CLI](/docs/cli#updating-the-project) or Dashboard)
+- Automatic document cleanup via `RemoveOnDetach` project setting (configure via [CLI](/docs/tools/cli#updating-the-project) or Dashboard)
 - Explicit "Save" action persists content to your database
 
 **Document Creation Flow:**
@@ -306,7 +306,7 @@ sequenceDiagram
     S-->>C: Deletion confirmed
 ```
 
-1. Client or server removes document via [Yorkie Admin API](/docs/admin-api#post-yorkiev1adminserviceremovedocument)
+1. Client or server removes document via [Yorkie Admin API](/docs/tools/admin-api#post-yorkiev1adminserviceremovedocument)
 2. Server removes document metadata from your database
 3. Document content is automatically removed from Yorkie
 
@@ -345,7 +345,7 @@ Explore real-world examples implementing these patterns:
 
 For more information about Yorkie's API and features:
 - [JS SDK Documentation](/docs/js-sdk) - Client and Document API reference
-- [Admin API](/docs/admin-api) - Admin API for server-side management
+- [Admin API](/docs/tools/admin-api) - Admin API for server-side management
 - [Security Configuration](/docs/advanced/security) - Auth Webhook and access control
-- [CLI](/docs/cli) - Command-line tools for project management
+- [CLI](/docs/tools/cli) - Command-line tools for project management
 - [Glossary](/docs/glossary) - Key terminology and concepts

--- a/docs/advanced/event-webhook.mdx
+++ b/docs/advanced/event-webhook.mdx
@@ -151,5 +151,5 @@ app.listen(3000, () => {
 ### Related Documentation
 
 - [Auth Webhook](/docs/advanced/security#auth-webhook) - For authorization and access control
-- [CLI Reference](/docs/cli) - Complete CLI command reference
+- [CLI Reference](/docs/tools/cli) - Complete CLI command reference
 - [Architecture Patterns](/docs/advanced/architecture-patterns) - Document lifecycle patterns

--- a/docs/advanced/projects.mdx
+++ b/docs/advanced/projects.mdx
@@ -1,0 +1,167 @@
+---
+title: 'Projects'
+order: 119
+---
+
+## Projects
+
+A **Project** in Yorkie is a logical grouping that isolates documents, channels, and clients. Projects enable multi-tenancy, allowing you to run multiple independent applications or environments within a single Yorkie installation.
+
+### Overview
+
+Every Yorkie installation starts with a `default` project that is created automatically. When a [Client](/docs/js-sdk#client) connects without specifying an API key, it is placed in the default project. For production applications, you should create dedicated projects to isolate data and configure settings independently.
+
+```mermaid
+graph TB
+    subgraph Server["Yorkie Server"]
+        subgraph P1["Project: my-app-prod"]
+            D1["Documents"]
+            C1["Channels"]
+            CL1["Clients"]
+        end
+        subgraph P2["Project: my-app-staging"]
+            D2["Documents"]
+            C2["Channels"]
+            CL2["Clients"]
+        end
+        subgraph P3["Project: another-app"]
+            D3["Documents"]
+            C3["Channels"]
+            CL3["Clients"]
+        end
+    end
+```
+
+### Project Isolation
+
+Each project provides complete isolation:
+
+- **Documents** in one project are invisible to clients in another project. A document key like `doc-1` can exist independently in multiple projects.
+- **Channels** are scoped to their project. Broadcast messages and presence updates only reach clients within the same project.
+- **Clients** belong to exactly one project, determined by the API key they use to connect.
+- **Configuration** (auth webhooks, event webhooks, resource limits, housekeeping thresholds) is set per project.
+
+### API Keys
+
+Each project has two keys:
+
+| Key | Purpose | Usage |
+|-----|---------|-------|
+| **Public Key** | Identifies the project for client connections | Used as `apiKey` when creating a [Client](/docs/js-sdk#client) |
+| **Secret Key** | Authenticates server-side applications | Used in the `authorization` header for [Admin API](/docs/tools/admin-api) requests |
+
+```javascript
+// Connect a client to a specific project using its public key
+const client = new yorkie.Client({
+  rpcAddr: '{{API_ADDR}}',
+  apiKey: 'your-project-public-key',
+});
+```
+
+> Keep your **Secret Key** confidential. It grants full access to manage documents within the project via the [Admin API](/docs/tools/admin-api). Never expose it in client-side code.
+
+### Managing Projects
+
+Projects are managed through the [CLI](/docs/tools/cli#project) or the [Dashboard]({{DASHBOARD_PATH}}).
+
+#### Creating a Project
+
+```bash
+$ yorkie project create my-app-prod
+```
+
+This returns the project details including both keys:
+
+```json
+{
+  "name": "my-app-prod",
+  "public_key": "...",
+  "secret_key": "...",
+  "created_at": "..."
+}
+```
+
+#### Listing Projects
+
+```bash
+$ yorkie project ls
+```
+
+#### Updating a Project
+
+Configure project settings such as auth webhooks, event webhooks, and resource limits:
+
+```bash
+# Set an auth webhook URL
+$ yorkie project update my-app-prod --auth-webhook-url https://my-server.com/auth
+
+# Configure event webhooks
+$ yorkie project update my-app-prod \
+  --event-webhook-url https://my-server.com/events \
+  --event-webhook-events-add DocumentRootChanged
+
+# Set resource limits
+$ yorkie project update my-app-prod \
+  --max-attachments-per-document 50 \
+  --max-subscribers-per-document 100
+
+# Configure housekeeping
+$ yorkie project update my-app-prod \
+  --client-deactivate-threshold 24h
+```
+
+For the full set of update options, see [Updating the Project](/docs/tools/cli#updating-the-project).
+
+### Per-Project Configuration
+
+Each project can be independently configured with the following settings:
+
+| Setting | Description | Reference |
+|---------|-------------|-----------|
+| **Auth Webhook** | External authentication endpoint for validating client requests | [Security: Auth Webhook](/docs/advanced/security#auth-webhook) |
+| **Event Webhook** | Notification endpoint for document events | [Event Webhook](/docs/advanced/event-webhook) |
+| **Allowed Origins** | CORS restrictions for client connections | [Security: Allowed Origins](/docs/advanced/security#allowed-origins) |
+| **Max Attachments** | Maximum clients that can attach to a single document | [Document Limits](/docs/js-sdk#document-limits) |
+| **Max Subscribers** | Maximum clients that can subscribe to a single document | [Document Limits](/docs/js-sdk#document-limits) |
+| **Client Deactivate Threshold** | Time after which inactive clients are automatically deactivated by [Housekeeping](/docs/glossary) | [CLI](/docs/tools/cli#updating-the-project) |
+
+### Common Patterns
+
+#### Separate Environments
+
+Create distinct projects for development, staging, and production:
+
+```bash
+$ yorkie project create my-app-dev
+$ yorkie project create my-app-staging
+$ yorkie project create my-app-prod
+```
+
+Use environment variables in your application to select the appropriate API key:
+
+```javascript
+const client = new yorkie.Client({
+  rpcAddr: process.env.YORKIE_RPC_ADDR,
+  apiKey: process.env.YORKIE_API_KEY,
+});
+```
+
+#### Multiple Applications
+
+If you host multiple collaborative applications on a single Yorkie server, create a project for each:
+
+```bash
+$ yorkie project create docs-app
+$ yorkie project create whiteboard-app
+$ yorkie project create chat-app
+```
+
+Each application's documents, channels, and client data remain fully isolated.
+
+### Further Reading
+
+- [CLI: Project Management](/docs/tools/cli#project) -- Full CLI reference for project commands
+- [Admin API](/docs/tools/admin-api) -- Server-side document management using the project's secret key
+- [Security](/docs/advanced/security) -- Configuring auth webhooks and allowed origins
+- [Resources](/docs/advanced/resources) -- Configuring project-level resource limits
+- [Glossary](/docs/glossary) -- Definitions of all key terms

--- a/docs/advanced/resources.mdx
+++ b/docs/advanced/resources.mdx
@@ -13,7 +13,7 @@ Resource settings can be configured through:
 
 - **CLI**: Using `yorkie project update` command
 - **Dashboard**: Through the project settings page
-- **Admin API**: Using the [UpdateProject](/docs/admin-api#post-yorkiev1adminserviceupdateproject) endpoint
+- **Admin API**: Using the [UpdateProject](/docs/tools/admin-api#post-yorkiev1adminserviceupdateproject) endpoint
 
 ### Document Limits
 
@@ -188,7 +188,7 @@ yorkie project update my-project \
 
 ### Related Documentation
 
-- [CLI Reference](/docs/cli) - Complete CLI command reference
-- [Admin API](/docs/admin-api) - API for project management
+- [CLI Reference](/docs/tools/cli) - Complete CLI command reference
+- [Admin API](/docs/tools/admin-api) - API for project management
 - [Architecture Patterns](/docs/advanced/architecture-patterns) - Document lifecycle patterns
 - [JS SDK - Document Events](/docs/js-sdk#documentsubscribesnapshot) - Handling snapshot events

--- a/docs/advanced/revisions.mdx
+++ b/docs/advanced/revisions.mdx
@@ -13,7 +13,7 @@ Revisions are immutable snapshots of a document's state stored on the server. Ea
 
 - **Label**: A user-friendly identifier (e.g., "v1.0", "Draft", "Final")
 - **Description**: Optional detailed explanation of what changed
-- **Snapshot**: The complete document state in [YSON](/docs/advanced/yson) format
+- **Snapshot**: The complete document state in [YSON](/docs/internals/yson) format
 - **Timestamp**: When the revision was created
 - **Server Sequence**: The document's server sequence number at creation time
 
@@ -29,7 +29,7 @@ Revisions are immutable snapshots of a document's state stored on the server. Ea
 
 This guide assumes familiarity with:
 1. [Client](/docs/js-sdk#client) and [Document](/docs/js-sdk#document) basics
-2. [YSON format](/docs/advanced/yson) for understanding snapshots
+2. [YSON format](/docs/internals/yson) for understanding snapshots
 
 ### How Revisions Work
 
@@ -298,7 +298,7 @@ When enabled:
 - Labels follow the format: `snapshot-{serverSeq}`
 - Descriptions: `Auto created revision of snapshot #{serverSeq}`
 
-Configure via the Dashboard or [Admin API](/docs/admin-api#post-yorkiev1adminserviceupdateproject). See [Resources](/docs/advanced/resources#autorevisionenabled) for details.
+Configure via the Dashboard or [Admin API](/docs/tools/admin-api#post-yorkiev1adminserviceupdateproject). See [Resources](/docs/advanced/resources#autorevisionenabled) for details.
 
 ### Best Practices
 
@@ -341,6 +341,6 @@ Revision operations require appropriate document permissions:
 ### Related Documentation
 
 - [JS SDK - Document Revisions](/docs/js-sdk#document-revisions) - Complete API reference
-- [YSON](/docs/advanced/yson) - Understanding snapshot format
+- [YSON](/docs/internals/yson) - Understanding snapshot format
 - [Resources](/docs/advanced/resources) - Project configuration including auto-revisions
 - [CodePair](https://github.com/yorkie-team/codepair) - Reference implementation

--- a/docs/advanced/security.mdx
+++ b/docs/advanced/security.mdx
@@ -55,7 +55,7 @@ You can set up the Auth Webhook via the [Dashboard]({{DASHBOARD_PATH}}):
 
 <Image alt="setting auth-webhook" src="/assets/images/docs/auth-webhook-dashboard.png" width={1300} height={840} style={{ maxWidth: '1000px' }} />
 
-Alternatively, configure the webhook using the Yorkie CLI. See [Updating the Project](/docs/cli#updating-the-project) for details.
+Alternatively, configure the webhook using the Yorkie CLI. See [Updating the Project](/docs/tools/cli#updating-the-project) for details.
 
 ##### 2. Client Configuration
 

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -12,50 +12,64 @@ These terms are used in the Yorkie project and community. Understanding them wil
 | Word | Description |
 | ---- | ----------- |
 | Yorkie | An open-source document store for building real-time collaborative applications. Sometimes it refers to the [main repository](https://github.com/yorkie-team/yorkie). |
-| Client | A regular client that communicates with the Yorkie server, synchronizing document changes for real-time collaboration. |
-| Server | The central component that manages documents and channels, stores changes, and facilitates communication between clients. |
-| Project | A logical grouping of documents, channels, and clients, allowing multiple independent services within a single Yorkie installation. |
+| [Client](/docs/js-sdk#client) | A regular client that communicates with the Yorkie server, synchronizing document changes for real-time collaboration. |
+| [Server](/docs/self-hosted-server) | The central component that manages documents and channels, stores changes, and facilitates communication between clients. |
+| [Project](/docs/advanced/projects) | A logical grouping of documents, channels, and clients, allowing multiple independent services within a single Yorkie installation. |
+| [Dashboard]({{DASHBOARD_PATH}}) | A web-based UI for managing Yorkie projects, monitoring documents, and viewing analytics such as MAU (Monthly Active Users). |
+| API Key | A project-specific key used to authenticate [Client](/docs/js-sdk#client) connections to the Yorkie server. Each project has a public key (used by clients) and a secret key (used by the [Admin API](/docs/tools/admin-api)). |
 
 ### Document & Data Structures
 
 | Word | Description |
 | ---- | ----------- |
-| Document | The primary data structure in Yorkie for persistent, collaborative data. It contains a presence and a root, and is stored in the database. Documents support offline editing and conflict-free synchronization using CRDTs. |
-| Root | The main JSON-like data structure(CRDT) within a document that can be shared and edited by multiple users. |
-| Change | A representation of modifications made to a document, created by calling `Document.Update()`. |
+| [Document](/docs/js-sdk#document) | The primary data structure in Yorkie for persistent, collaborative data. It contains a presence and a root, and is stored in the database. Documents support offline editing and conflict-free synchronization using CRDTs. |
+| [Root](/docs/js-sdk#initializing-root) | The main JSON-like data structure(CRDT) within a document that can be shared and edited by multiple users. |
+| [Change](/docs/js-sdk#editing-the-document) | A representation of modifications made to a document, created by calling `Document.Update()`. |
 | Schema | An optional validation key that can be specified when attaching a document to ensure it conforms to a predefined structure or set of rules. |
-| YSON | Yorkie JSON (YSON) is a JSON-like format for representing Yorkie documents, including custom CRDT types such as `Text`, `Tree`, `Counter`, along with specialized types like `Int`, `Long`, `Date`, and `BinData`. Used for document snapshots and serialization. |
+| [YSON](/docs/internals/yson) | Yorkie JSON (YSON) is a JSON-like format for representing Yorkie documents, including custom CRDT types such as `Text`, `Tree`, `Counter`, along with specialized types like `Int`, `Long`, `Date`, and `BinData`. Used for document snapshots and serialization. |
+| [Text](/docs/js-sdk#custom-crdt-types) | A list-based CRDT type for collaborative rich text editing. Supports styling attributes and cursor sharing via presence. Used for integrations like [Quill](/examples/quill) and [CodeMirror](/examples/codemirror). |
+| [Tree](/docs/js-sdk#custom-crdt-types) | A tree-based CRDT type for structured rich text editing. Represents content as a hierarchical tree of nodes, similar to a DOM structure. |
+| [Counter](/docs/js-sdk#custom-crdt-types) | A CRDT type for concurrent counting operations. Supports integer and long types, allowing multiple users to increment or decrement a value simultaneously without conflicts. |
 
 ### Real-time Collaboration
 
 | Word | Description |
 | ---- | ----------- |
-| Channel | A lightweight, memory-only communication layer for real-time features like presence tracking and message broadcasting. Unlike Documents, Channels do not persist data to the database and are designed for ephemeral data. |
-| Broadcast | A messaging mechanism within Channels that allows clients to publish and subscribe to real-time events without persisting the data. Useful for chat messages, notifications, and other ephemeral communications. |
-| Presence | A data structure representing a user's current state within a document (e.g., cursor position, selection). |
+| [Channel](/docs/js-sdk#channel) | A lightweight, memory-only communication layer for real-time features like presence tracking and message broadcasting. Unlike Documents, Channels do not persist data to the database and are designed for ephemeral data. |
+| [Broadcast](/docs/js-sdk#broadcast) | A messaging mechanism within Channels that allows clients to publish and subscribe to real-time events without persisting the data. Useful for chat messages, notifications, and other ephemeral communications. |
+| [Presence](/docs/js-sdk#presence) | A data structure representing a user's current state within a document (e.g., cursor position, selection). |
+| Attach / Detach | The operations that subscribe or unsubscribe a [Client](/docs/js-sdk#client) to/from a [Document](/docs/js-sdk#attaching-the-document) or [Channel](/docs/js-sdk#channel). Attaching synchronizes state with the server; detaching releases the subscription and cleans up resources. |
 
 ### Synchronization & State Management
 
 | Word | Description |
 | ---- | ----------- |
-| Sync Mode | The synchronization mode that determines how a document syncs with the server. Options include: `Realtime` (automatic push and pull), `RealtimePushOnly` (push only), `RealtimeSyncOff` (no sync but watch stream active), and `Manual` (requires manual sync calls). |
-| Snapshot | A complete state of a document at a specific point in time. When the number of changes exceeds a threshold, the server sends a snapshot instead of individual changes to optimize synchronization performance. |
-| Revision | An immutable snapshot of a document at a specific point in time with metadata (label, description, timestamp). Revisions allow users to browse document history, preview previous states, and restore documents to earlier versions. See [Document Revisions](/docs/advanced/revisions). |
-| PushPullChanges | An API for bidirectional synchronization of changes between clients and the server. |
-| Checkpoint | A mechanism for tracking the synchronization state between clients and the server, consisting of ServerSeq and ClientSeq. |
+| [Sync Mode](/docs/js-sdk#synchronization-modes) | The synchronization mode that determines how a document syncs with the server. Options include: `Realtime` (automatic push and pull), `RealtimePushOnly` (push only), `RealtimeSyncOff` (no sync but watch stream active), and `Manual` (requires manual sync calls). For more details, see [Synchronization](/docs/internals/synchronization). |
+| [Snapshot](/docs/internals/synchronization#snapshots) | A complete state of a document at a specific point in time. When the number of changes exceeds a threshold, the server sends a snapshot instead of individual changes to optimize synchronization performance. |
+| [Revision](/docs/advanced/revisions) | An immutable snapshot of a document at a specific point in time with metadata (label, description, timestamp). Revisions allow users to browse document history, preview previous states, and restore documents to earlier versions. |
+| [PushPullChanges](/docs/internals/synchronization#pushpullchanges) | An API for bidirectional synchronization of changes between clients and the server. |
+| [Checkpoint](/docs/internals/synchronization#checkpoints) | A mechanism for tracking the synchronization state between clients and the server, consisting of ServerSeq and ClientSeq. |
+| [Watch Stream](/docs/internals/synchronization#the-watch-stream) | A persistent gRPC server-side streaming connection between a client and the server. Delivers real-time events (`DocChanged`, `DocWatched`, `DocUnwatched`) using a PubSub pattern, enabling [Presence](/docs/js-sdk#presence) and automatic change pulling. |
+| [Document Compaction](/docs/internals/synchronization#document-compaction) | A server-side process that consolidates old change history into a single snapshot to reduce storage overhead. Performed by [Housekeeping](/docs/glossary) on documents that are not currently attached. |
 
 ### CRDT Internals
 
 | Word | Description |
 | ---- | ----------- |
-| CRDT Element | A data structure representing a CRDT element, analogous to an Element in the DOM. For more information, see [Data Structures](https://github.com/yorkie-team/yorkie/blob/main/design/data-structure.md). |
-| CRDT Node | A single node within a CRDT element. |
-| Tombstone | A marker for a deleted node or element in CRDT. |
-| Garbage Collection | The process of removing nodes marked as tombstones to optimize storage and performance. |
+| [CRDT Element](/docs/internals/crdt-concepts#crdt-elements-and-nodes) | A data structure representing a CRDT element, analogous to an Element in the DOM. For more information, see [CRDT Concepts](/docs/internals/crdt-concepts) and the [Data Structures design doc](https://github.com/yorkie-team/yorkie/blob/main/design/data-structure.md). |
+| [CRDT Node](/docs/internals/crdt-concepts#crdt-elements-and-nodes) | A single node within a CRDT element. |
+| [TimeTicket](/docs/internals/crdt-concepts#timetickets) | A globally unique identifier for every CRDT node, composed of a Lamport timestamp, an ActorID (the creating client), and a delimiter. TimeTickets provide both uniqueness and a total ordering for conflict resolution. |
+| [Version Vector](/docs/internals/crdt-concepts#version-vectors) | A Lamport Synced Version Vector -- a hybrid logical clock that combines Lamport timestamps with version vectors. Used to track causal relationships between clients for [Garbage Collection](/docs/internals/crdt-concepts#garbage-collection). |
+| [RHT](/docs/internals/crdt-concepts#replicated-hash-table-rht) | Replicated Hash Table -- the CRDT backing Yorkie's `Object` type. Resolves concurrent key updates using Lamport timestamps (last-writer-wins per key). |
+| [RGA](/docs/internals/crdt-concepts#replicated-growable-array-rga) | Replicated Growable Array -- the CRDT backing Yorkie's `Array` and `Text` types. Supports concurrent insertions with deterministic ordering using `insertAfter` semantics. |
+| [Tombstone](/docs/internals/crdt-concepts#tombstones) | A marker for a deleted node or element in CRDT. Tombstoned nodes remain in memory until all clients have synced past the deletion. |
+| [Garbage Collection](/docs/internals/crdt-concepts#garbage-collection) | The process of removing nodes marked as tombstones to optimize storage and performance. Uses the `minVersionVector` to determine when it is safe to purge tombstones. |
 
 ### Server Management
 
 | Word | Description |
 | ---- | ----------- |
-| Admin API | A REST API that allows server-side applications to programmatically manage Yorkie documents without using the Yorkie SDK. Useful for server-side document management, automation, and integration. |
-| Housekeeping | A maintenance process that cleans up unnecessary data on the server. |
+| [Admin API](/docs/tools/admin-api) | A REST API that allows server-side applications to programmatically manage Yorkie documents without using the Yorkie SDK. Useful for server-side document management, automation, and integration. |
+| [Auth Webhook](/docs/advanced/security#auth-webhook) | A server-side webhook that validates client requests through an external authentication server, providing fine-grained access control for documents. See [Security](/docs/advanced/security). |
+| [Event Webhook](/docs/advanced/event-webhook) | A webhook that notifies external services when specific events occur in Yorkie documents (e.g., `DocumentRootChanged`). Useful for integrations, notifications, and external system synchronization. |
+| Housekeeping | A maintenance process that cleans up unnecessary data on the server, such as deactivating clients that exceed the `client-deactivate-threshold`. Configured via [CLI](/docs/tools/cli#updating-the-project). |

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -23,8 +23,8 @@ Unlike other CRDT libraries like AutoMerge and Yjs that only provide data struct
 - Client SDKs for [JavaScript](/docs/js-sdk), [React](/docs/getting-started/with-react), [Android](/docs/android-sdk), and [iOS](/docs/ios-sdk)
 - Managed Cloud Service or [Self-Hosted Server](/docs/self-hosted-server) options
 - Built-in Infrastructure for data persistence, synchronization, and scaling
-- [Admin APIs](/docs/admin-api) for server-side document management
-- [Dashboard](https://yorkie.dev/dashboard) and [CLI](/docs/cli) for project management and monitoring
+- [Admin APIs](/docs/tools/admin-api) for server-side document management
+- [Dashboard](https://yorkie.dev/dashboard) and [CLI](/docs/tools/cli) for project management and monitoring
 
 This means you can focus on building your application's features instead of managing collaboration infrastructure.
 
@@ -37,7 +37,7 @@ Yorkie consists of four main components that work together to enable real-time c
 - [Channel](/docs/js-sdk#channel): A lightweight, memory-only communication layer for ephemeral data. Ideal for presence tracking (who's online, cursor positions) and real-time message broadcasting.
 - [Server](/docs/self-hosted-server): The central hub that receives changes from clients, persists them to the database, and broadcasts updates to subscribed clients. Available as a managed cloud service or self-hosted.
 
-Additionally, **[Projects](/docs/cli#project)** allow you to organize multiple independent applications within a single Yorkie installation, each with its own documents, channels, and clients. Learn more about key concepts in the [Glossary](/docs/glossary).
+Additionally, **[Projects](/docs/tools/cli#project)** allow you to organize multiple independent applications within a single Yorkie installation, each with its own documents, channels, and clients. Learn more about key concepts in the [Glossary](/docs/glossary).
 
 Yorkie offers flexibility in how you deploy:
 - **Cloud**: Get started instantly with our managed service - no infrastructure setup required
@@ -111,5 +111,5 @@ Explore more [examples](/examples) to see what you can build with Yorkie.
 **Dive Deeper:**
 - Understand [Architecture Patterns](/docs/advanced/architecture-patterns) to design your collaboration system
 - Learn about [security best practices](/docs/advanced/security) for production deployments
-- Explore [CLI commands](/docs/cli) for managing your projects
+- Explore [CLI commands](/docs/tools/cli) for managing your projects
 - Check the [Glossary](/docs/glossary) for terminology reference

--- a/docs/internals.mdx
+++ b/docs/internals.mdx
@@ -1,0 +1,24 @@
+---
+title: 'Internals'
+order: 120
+---
+
+## Internals
+
+This section explains how Yorkie works under the hood and how to deploy it at scale. These topics are for those who want a deeper understanding of Yorkie's CRDT engine, synchronization mechanisms, and production infrastructure.
+
+### Topics
+
+- **[CRDT Concepts](/docs/internals/crdt-concepts)**: Understand how Yorkie uses CRDTs for conflict-free collaboration, including data structure hierarchy, logical clocks, elements, nodes, tombstones, and garbage collection
+- **[Synchronization](/docs/internals/synchronization)**: Learn how Yorkie keeps document replicas consistent through sync modes, PushPullChanges, checkpoints, snapshots, and the watch stream
+- **[Document Lifecycle](/docs/internals/document-lifecycle)**: Understand the state transitions of documents and clients, from attachment through detachment and removal
+- **[YSON](/docs/internals/yson)**: Learn about Yorkie Structured Object Notation, the data format used to represent documents with specialized types for collaborative editing
+- **[Cluster Mode](/docs/internals/cluster-mode)**: Deploy Yorkie in production with sharded cluster mode, consistent hashing, leader election, and MongoDB sharding
+
+### Prerequisites
+
+Before exploring these topics, ensure you have:
+1. Completed the [Getting Started guide](/docs/getting-started)
+2. Built at least one application using Yorkie SDKs
+3. Understood basic concepts like [Client](/docs/js-sdk#client), [Document](/docs/js-sdk#document), and [Channel](/docs/js-sdk#channel)
+4. Reviewed [Configuration](/docs/advanced) topics and the [Glossary](/docs/glossary)

--- a/docs/internals/cluster-mode.mdx
+++ b/docs/internals/cluster-mode.mdx
@@ -1,0 +1,186 @@
+---
+title: 'Cluster Mode'
+order: 125
+---
+
+## Cluster Mode
+
+For production deployments that require high availability, scalability, and reliability, Yorkie provides a **sharded cluster mode**. This page explains how clustering works and the key architectural concepts behind it.
+
+### Overview
+
+In a single-server setup, all documents and clients are handled by one Yorkie instance. As your workload grows, a cluster distributes the load across multiple Yorkie servers, each responsible for a subset of documents.
+
+Yorkie's cluster mode uses **document-based sharding** with consistent hashing to route requests for the same document to the same server. This eliminates the need for servers to share document state with each other.
+
+```mermaid
+graph LR
+    subgraph Clients
+        C1["Client A"]
+        C2["Client B"]
+        C3["Client C"]
+    end
+
+    subgraph Proxy["Load Balancer (Consistent Hashing)"]
+        LB["Route by document key"]
+    end
+
+    subgraph Cluster["Yorkie Cluster"]
+        S1["Server 1<br/>docs: A, D"]
+        S2["Server 2<br/>docs: B, E"]
+        S3["Server 3<br/>docs: C, F"]
+    end
+
+    subgraph DB["Shared Database"]
+        MongoDB["MongoDB"]
+    end
+
+    C1 --> LB
+    C2 --> LB
+    C3 --> LB
+    LB --> S1
+    LB --> S2
+    LB --> S3
+    S1 --> MongoDB
+    S2 --> MongoDB
+    S3 --> MongoDB
+```
+
+### Sharding Strategy
+
+The cluster mode uses **consistent hashing** to map documents to servers:
+
+- Each server is assigned positions on a virtual hash ring.
+- When a request arrives, the document key is hashed and routed to the nearest server on the ring (clockwise).
+- When a server is added or removed, only a minimal number of documents are remapped (this property is called **minimal disruption**).
+
+Yorkie supports two consistent hashing algorithms:
+
+| Algorithm | Description | Best For |
+|-----------|-------------|----------|
+| **Ring Hash** | Classic consistent hashing with virtual nodes on a ring | General purpose, simpler configuration |
+| **Maglev** | Google's load balancer algorithm using preference lists and lookup tables | More efficient rehashing, better load balancing |
+
+### Architecture Components
+
+A Yorkie cluster consists of three components:
+
+| Component | Role | Analogous To |
+|-----------|------|-------------|
+| **Router (Proxy)** | Receives client requests and routes them to the correct server based on consistent hashing | MongoDB `mongos` |
+| **Service Registry** | Stores metadata and locations of all Yorkie servers | MongoDB config server |
+| **Yorkie Servers** | Individual server instances that process document operations | MongoDB `mongod` shards |
+
+### Kubernetes and Istio Implementation
+
+The recommended way to deploy a Yorkie cluster is with [Kubernetes](https://kubernetes.io/) and [Istio](https://istio.io/):
+
+| Cluster Component | K8s/Istio Implementation |
+|-------------------|-------------------------|
+| Router (Proxy) | Istio Ingress Gateway (Envoy) |
+| Service Registry | Istio Pilot (istiod) + etcd |
+| Yorkie Servers | Kubernetes Pods/Deployments |
+
+Istio's `DestinationRule` resource configures consistent hash-based routing:
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: yorkie
+spec:
+  host: yorkie
+  trafficPolicy:
+    portLevelSettings:
+      - port:
+          number: 8080
+        loadBalancer:
+          consistentHash:
+            ringHash:
+              minimumRingSize: 1024
+            httpHeaderName: "x-shard-key"
+```
+
+The `x-shard-key` header (containing the project and document key) determines which server handles the request.
+
+For step-by-step deployment guides, see [Self-Hosted Server on Minikube](/docs/self-hosted-server/minikube) and [Self-Hosted Server on AWS EKS](/docs/self-hosted-server/aws-eks).
+
+### Membership Management
+
+In a cluster, Yorkie uses a **leader-member structure** for coordinating cluster-wide tasks:
+
+- **Leader**: A single node elected to handle cluster-wide operations like [Housekeeping](/docs/glossary) (client deactivation and document compaction).
+- **Members**: All other nodes that process client requests normally.
+
+Leader election is enforced at the database level:
+
+- A database-level unique index guarantees at most one leader at a time.
+- The leader periodically renews its **lease** (default: every 5 seconds, with a 15-second lease duration).
+- If the leader fails to renew, another member acquires leadership.
+- Short periods with no leader are tolerated -- only housekeeping tasks are delayed, and user-facing requests remain unaffected.
+
+All nodes send periodic **heartbeats** to the database to indicate they are alive. The cluster uses a **liveness window** (default: 10 seconds) to detect inactive nodes.
+
+For the full design, see the [Membership Management design document](https://github.com/yorkie-team/yorkie/blob/main/design/membership.md).
+
+### MongoDB Sharding
+
+For large-scale deployments, Yorkie supports **sharded MongoDB clusters** to distribute data and query loads:
+
+| Collection Scope | Collections | Shard Key | Method |
+|-----------------|-------------|-----------|--------|
+| **Cluster-wide** | `users`, `projects` | Not sharded (small data volume) | N/A |
+| **Project-wide** | `clients`, `documents`, `schemas` | `project_id` (+ `_id` for clients) | Ranged / Hashed |
+| **Document-wide** | `changes`, `snapshots`, `versionvectors`, `revisions` | `doc_id` | Hashed |
+
+Hashed sharding on `doc_id` for document-wide collections provides:
+- **Even data distribution**: Prevents hotspots from sequential ObjectID generation.
+- **Improved write performance**: Writes are distributed across all shards.
+- **Better scalability**: New shards immediately participate in handling traffic.
+
+For the full sharding strategy, see the [MongoDB Sharding design document](https://github.com/yorkie-team/yorkie/blob/main/design/mongodb-sharding.md).
+
+### Watch Stream in Cluster Mode
+
+The [Watch Stream](/docs/internals/synchronization#the-watch-stream) uses long-lived gRPC connections. When the cluster topology changes (servers added/removed), existing connections may not be automatically rerouted. Yorkie mitigates this with:
+
+- **gRPC Max Connection Age**: Periodically closes long-lived connections, forcing reconnection to the correct server.
+- **Envoy Stream Idle Timeout**: Closes idle connections that may be "split-brained" (connected to the wrong server after a topology change).
+
+These mechanisms ensure that all clients eventually reconnect to the correct server after topology changes.
+
+### Fine-Grained Document Locking
+
+To maximize concurrency on popular documents, Yorkie uses **fine-grained locking** instead of a single document lock:
+
+| Lock | Purpose |
+|------|---------|
+| **`doc`** (RW Lock) | Coordinates between normal operations (read lock) and compaction (write lock) |
+| **`doc.pull`** | Ensures consistency when pulling changes from the server |
+| **`doc.attachment`** | Protects attach/detach operations and attachment limit checks |
+| **`doc.push`** | Ensures consistency when pushing changes to the server |
+
+Locks are always acquired in order (`doc` → `doc.pull` → `doc.attachment` → `doc.push`) to prevent deadlocks. This allows concurrent reads during compaction and independent push/pull operations.
+
+For the full design, see the [Fine-Grained Document Locking design document](https://github.com/yorkie-team/yorkie/blob/main/design/fine-grained-document-locking.md).
+
+### Production Deployment Considerations
+
+When deploying a Yorkie cluster in production:
+
+- **Database redundancy**: Use a MongoDB replica set (recommended: 3 members per shard) for data safety.
+- **Multiple routers**: Deploy at least 2 Istio Ingress Gateways for high availability.
+- **Monitoring**: Track leader election failures, heartbeat timestamps, lock wait times, and broadcast success rates.
+- **Housekeeping tuning**: Adjust the `Interval`, `CandidatesLimit`, and `CompactionMinChanges` settings based on your workload. See the [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/design/housekeeping.md) for configuration examples.
+
+### Further Reading
+
+- [Self-Hosted Server](/docs/self-hosted-server) -- How to run your own Yorkie server
+- [Self-Hosted Server on Minikube](/docs/self-hosted-server/minikube) -- Local Kubernetes deployment guide
+- [Self-Hosted Server on AWS EKS](/docs/self-hosted-server/aws-eks) -- AWS deployment guide
+- [Cluster Addons](/docs/self-hosted-server/cluster-addons) -- Additional components for cluster deployments
+- [Sharded Cluster Mode design document](https://github.com/yorkie-team/yorkie/blob/main/design/sharded-cluster-mode.md) -- Full consistent hashing design
+- [Membership Management design document](https://github.com/yorkie-team/yorkie/blob/main/design/membership.md) -- Leader election and node lifecycle
+- [MongoDB Sharding design document](https://github.com/yorkie-team/yorkie/blob/main/design/mongodb-sharding.md) -- Database sharding strategy
+- [Fine-Grained Document Locking design document](https://github.com/yorkie-team/yorkie/blob/main/design/fine-grained-document-locking.md) -- Concurrency optimization
+- [Glossary](/docs/glossary) -- Definitions of all key terms

--- a/docs/internals/crdt-concepts.mdx
+++ b/docs/internals/crdt-concepts.mdx
@@ -1,0 +1,231 @@
+---
+title: 'CRDT Concepts'
+order: 121
+---
+
+## CRDT Concepts
+
+Yorkie uses Conflict-free Replicated Data Types (CRDTs) to enable real-time collaboration without coordination between clients. This page explains the key CRDT concepts that underpin Yorkie's data model.
+
+### What Are CRDTs?
+
+CRDTs are data structures that can be replicated across multiple clients, where each client can update its replica independently, and all replicas are guaranteed to converge to the same state. This means multiple users can edit a [Document](/docs/js-sdk#document) simultaneously without conflicts, even while offline.
+
+Unlike traditional conflict resolution approaches (such as Operational Transformation used by Google Docs), CRDTs provide mathematically guaranteed convergence. Every operation that can be applied to a CRDT is designed so that, regardless of the order operations are received, the final state is always the same.
+
+### How Yorkie Uses CRDTs
+
+Yorkie's [Document](/docs/js-sdk#document) is built on a CRDT-based data structure. When you call `document.update()`, the changes you make to the [Root](/docs/js-sdk#initializing-root) are internally represented as CRDT operations. These operations are then synchronized with the [Server](/docs/self-hosted-server) and delivered to other clients via the [PushPullChanges](/docs/internals/synchronization#pushpullchanges) mechanism.
+
+```mermaid
+graph LR
+    subgraph ClientA["Client A"]
+        DocA["Document Replica"]
+    end
+    subgraph ClientB["Client B"]
+        DocB["Document Replica"]
+    end
+    subgraph Server["Yorkie Server"]
+        DocS["Canonical State"]
+    end
+
+    DocA -->|"CRDT Operations"| DocS
+    DocS -->|"CRDT Operations"| DocB
+    DocB -->|"CRDT Operations"| DocS
+    DocS -->|"CRDT Operations"| DocA
+```
+
+### Data Structure Hierarchy
+
+Yorkie organizes its internal data structures into three layers, each building on the one below:
+
+#### JSON-like Layer
+
+These are the data types you interact with directly when editing documents through `document.update()`:
+
+| Type | Description | Underlying CRDT |
+|------|-------------|-----------------|
+| **Primitive** | Basic values: `string`, `number`, `boolean`, `null` | N/A (immutable values) |
+| **Object** | Key-value pairs, like a JavaScript object or hash table | [RHT](#replicated-hash-table-rht) (Replicated Hash Table) |
+| **Array** | Ordered list of values | [RGATreeList](#replicated-growable-array-rga) |
+| **[Text](/docs/js-sdk#custom-crdt-types)** | Rich text with style attributes for editors like [Quill](/examples/quill) and [CodeMirror](/examples/codemirror) | RGATreeSplit |
+| **[Counter](/docs/js-sdk#custom-crdt-types)** | Concurrent counter for increment/decrement operations | CRDT Counter |
+| **[Tree](/docs/js-sdk#custom-crdt-types)** | Tree structure for block-based editors like ProseMirror | [CRDTTree](#the-tree-crdt) |
+
+#### CRDT Layer
+
+These data structures resolve conflicts in concurrent editing. They are used internally by the JSON-like layer:
+
+| Type | Description |
+|------|-------------|
+| **RHT** (Replicated Hash Table) | A hash table that resolves concurrent key updates using [Lamport timestamps](#logical-clocks-and-timetickets). See [RHT section](#replicated-hash-table-rht). |
+| **ElementRHT** | An RHT variant that stores CRDT elements as values. |
+| **RGATreeList** | An RGA (Replicated Growable Array) with an index tree for fast positional access. See [RGA section](#replicated-growable-array-rga). |
+| **RGATreeSplit** | An RGA variant that represents characters as blocks rather than individual characters, optimizing text editing. |
+| **CRDTTree** | A tree CRDT that resolves conflicts in concurrent tree editing. See [Tree section](#the-tree-crdt). |
+
+#### Common Layer
+
+General-purpose data structures used by the CRDT layer:
+
+| Type | Description |
+|------|-------------|
+| **[SplayTree](https://en.wikipedia.org/wiki/Splay_tree)** | A self-adjusting binary search tree. Moves frequently accessed nodes to the root, which is effective for text editing where users access nearby positions. Used as an index tree to provide fast positional access. |
+| **[LLRBTree](https://en.wikipedia.org/wiki/Left-leaning_red%E2%80%93black_tree)** | A left-leaning red-black tree. Simpler than a standard red-black tree, used for ordered key lookups. |
+| **IndexTree** | A tree structure representing the document model of text-based editors. |
+
+For the full dependency graph and technical details, see the [Data Structures design document](https://github.com/yorkie-team/yorkie/blob/main/design/data-structure.md).
+
+### Logical Clocks and TimeTickets
+
+In a distributed system, physical clocks on different machines can disagree about the current time. Yorkie uses **logical clocks** to establish a consistent ordering of events across all clients.
+
+#### Lamport Timestamps
+
+A [Lamport timestamp](https://en.wikipedia.org/wiki/Lamport_timestamp) is a counter that increments with every operation. When a client receives changes from another client, it updates its own counter to at least match the received timestamp. This ensures that all clients can agree on the order of operations.
+
+#### TimeTickets
+
+In Yorkie, every CRDT node is identified by a **TimeTicket** -- a unique ID composed of:
+
+| Field | Purpose |
+|-------|---------|
+| **Lamport** | The Lamport timestamp at the time of creation |
+| **ActorID** | The unique ID of the client that created the node |
+| **Delimiter** | Distinguishes multiple nodes created in the same operation |
+
+TimeTickets provide global uniqueness: no two nodes across any clients will ever share the same TimeTicket. They also define a total ordering, which is used for conflict resolution (e.g., last-writer-wins uses the Lamport value to determine which write is "later").
+
+#### Version Vectors
+
+While Lamport timestamps provide ordering, they cannot fully capture **causal relationships** between events. For [Garbage Collection](/docs/internals/crdt-concepts#garbage-collection), Yorkie needs to know whether all clients have observed a particular deletion -- not just that the deletion has a certain timestamp.
+
+To solve this, Yorkie uses a **Lamport Synced Version Vector** -- a hybrid of Lamport timestamps and [Version Vectors](https://en.wikipedia.org/wiki/Version_vector):
+
+- Each client maintains a vector with one entry per participant, tracking the latest Lamport value it has seen from each client.
+- During synchronization, vectors are merged by taking the maximum value for each entry, with the additional Lamport merge rule applied to keep the vector synchronized with the Lamport clock.
+- This ensures both the causal guarantees of Version Vectors and compatibility with Yorkie's TimeTicket-based node IDs.
+
+The server uses the **minimum Version Vector** (`minVersionVector`) across all active clients to determine when tombstoned nodes can be safely garbage collected.
+
+For the full technical design, see the [Version Vector design document](https://github.com/yorkie-team/yorkie/blob/main/design/version-vector.md).
+
+### CRDT Elements and Nodes
+
+Yorkie organizes its data model into **CRDT Elements** and **CRDT Nodes**:
+
+- **CRDT Element**: A data structure analogous to an Element in the DOM. Each element has a unique identifier ([TimeTicket](#timetickets)) that ensures global uniqueness across all clients. Elements include JSON objects, arrays, primitive values, and the specialized types like [Text](/docs/js-sdk#custom-crdt-types), [Tree](/docs/js-sdk#custom-crdt-types), and [Counter](/docs/js-sdk#custom-crdt-types).
+
+- **CRDT Node**: A single node within a CRDT element. For example, in a [Text](/docs/js-sdk#custom-crdt-types) element, each character (or group of characters inserted at once) is a node. In a [Tree](/docs/js-sdk#custom-crdt-types) element, each tree node (element or text) is a CRDT node.
+
+The element-node hierarchy allows Yorkie to track fine-grained changes. Each node carries metadata (its creator, creation time, and position) that enables the system to merge concurrent edits correctly.
+
+### Replicated Hash Table (RHT)
+
+The **Replicated Hash Table (RHT)** is the CRDT that backs Yorkie's `Object` type. It works like a regular hash table, but resolves concurrent updates to the same key using [Lamport timestamps](#logical-clocks-and-timetickets):
+
+- When two clients set the same key simultaneously, the update with the higher Lamport timestamp wins.
+- Each key-value pair carries the TimeTicket of its last write, so the system always knows which write is the "latest."
+
+The **ElementRHT** variant stores CRDT elements (rather than simple values) as map values, enabling nested objects and arrays within documents.
+
+### Replicated Growable Array (RGA)
+
+The **Replicated Growable Array (RGA)** is the CRDT that backs Yorkie's `Array` and `Text` types. It provides:
+
+- **Concurrent insertion**: Multiple clients can insert at the same position. Insertions always use `insertAfter` (never `insertBefore`) to ensure deterministic ordering, with ties broken by [TimeTickets](#timetickets).
+- **Positional access via index tree**: Yorkie extends the basic RGA with a [SplayTree](https://en.wikipedia.org/wiki/Splay_tree)-based index, called **RGATreeList**, providing fast access to elements by their integer index.
+- **Block-based text**: For text editing, **RGATreeSplit** groups consecutive characters inserted by the same operation into blocks rather than storing each character individually. This significantly reduces memory usage and improves performance for text-heavy documents.
+
+### The Tree CRDT
+
+The **Tree CRDT** (`CRDTTree`) represents hierarchical document structures for block-based text editors like [ProseMirror](https://prosemirror.net/). It supports XML-like trees with element nodes (which can have attributes) and text nodes.
+
+#### Coordinate Systems
+
+The Tree uses a layered coordinate system to translate user actions into CRDT operations:
+
+1. **Index** (user-facing): An integer position similar to [ProseMirror's indexing](https://prosemirror.net/docs/guide/#doc.indexing), where positions are assigned at every point a cursor can reach.
+2. **IndexTree.TreePos** (physical): The actual position within the local tree structure, found by converting the index.
+3. **CRDTTree.TreeNodeID** (logical): A globally unique ID for each tree node, composed of a [TimeTicket](#timetickets) and an offset.
+4. **CRDTTree.TreePos** (CRDT): The final coordinate used in Edit and Style operations, consisting of a parent node ID and a left sibling node ID.
+
+For local editing, the conversion follows: `index` → `IndexTree.TreePos` → `CRDTTree.TreePos`. For remote editing (applying changes from other clients), the process starts directly from `CRDTTree.TreePos`, skipping the index conversion.
+
+#### Concurrent Tree Editing
+
+The Tree CRDT guarantees eventual consistency across 27 concurrent editing cases (combinations of range type, node type, and edit type). Key mechanisms include:
+
+- **`insertAfter` only**: Like the RGA, all insertions reference a left sibling node, ensuring deterministic ordering.
+- **`maxCreatedAtMapByActor`**: A map that tracks the latest creation time per actor within an editing range, enabling the system to distinguish concurrent from causally related operations and prevent unintended deletions.
+
+For the full technical design, see the [Tree design document](https://github.com/yorkie-team/yorkie/blob/main/design/tree.md).
+
+### Tombstones
+
+When a user deletes content in a collaborative document, Yorkie does not immediately remove the underlying node. Instead, it marks the node with a **tombstone** -- a soft-delete marker indicating that the node has been logically deleted.
+
+Tombstones are necessary because:
+
+1. **Concurrent operations may reference deleted nodes.** If Client A deletes a character while Client B is editing adjacent text, the CRDT needs the deleted node's metadata to correctly merge the operations.
+2. **Ordering guarantees.** CRDTs rely on every client seeing the same set of operations. Removing a node immediately could cause replicas to diverge.
+
+A tombstoned node is invisible to the application (it won't appear in your document's data), but it still occupies memory and storage until [Garbage Collection](#garbage-collection) reclaims it.
+
+### Garbage Collection
+
+Over time, tombstoned nodes accumulate and can degrade performance. **Garbage Collection (GC)** is the process of permanently removing these tombstoned nodes when they are no longer needed for conflict resolution.
+
+Yorkie's garbage collection uses [Version Vectors](#version-vectors) to determine when it's safe to remove tombstones:
+
+1. **Server tracks version vectors**: Every time a client synchronizes via PushPull, the server records that client's version vector.
+2. **Compute `minVersionVector`**: The server computes the minimum across all active clients' version vectors. This represents the set of changes that all clients have definitely received.
+3. **GC condition**: A tombstoned node can be collected when `minVersionVector[removedAt.actor] >= removedAt.lamport` -- meaning every active client has seen the change that deleted this node.
+4. **Client-side GC**: The server returns the `minVersionVector` in PushPull responses. Each client uses it to purge eligible tombstones from its local replica.
+
+```mermaid
+sequenceDiagram
+    participant A as Client A
+    participant S as Server
+    participant B as Client B
+
+    A->>S: Delete node X (tombstoned)
+    S->>B: Sync: node X tombstoned
+    B->>S: PushPull (version vector updated)
+    Note over S: minVersionVector now covers deletion
+    S->>A: PushPull response with minVersionVector
+    Note over A: GC: remove node X
+    S->>B: PushPull response with minVersionVector
+    Note over B: GC: remove node X
+```
+
+#### Text-Specific Garbage Collection
+
+For [Text](/docs/js-sdk#custom-crdt-types) types, GC works at the text node level within the RGATreeSplit structure. Tombstoned text nodes are cached during editing and removed from the linked list during garbage collection, making them eligible for runtime memory reclamation. For details, see the [GC for Text Type design document](https://github.com/yorkie-team/yorkie/blob/main/design/gc-for-text-type.md).
+
+For the full GC design, see the [Garbage Collection design document](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md).
+
+### Conflict Resolution in Practice
+
+Yorkie handles concurrent edits differently depending on the data type:
+
+| Data Type | Conflict Strategy | Example |
+|-----------|-------------------|---------|
+| **Object** | Last-writer-wins per key (via [RHT](#replicated-hash-table-rht)) | Two users set `root.title` simultaneously; the later [TimeTicket](#timetickets) wins |
+| **Array** | Position-based insertion (via [RGA](#replicated-growable-array-rga)) | Two users insert at the same index; both items appear in a deterministic order |
+| **[Text](/docs/js-sdk#custom-crdt-types)** | Character-level merge (via RGATreeSplit) | Two users type at the same position; both characters appear based on their TimeTickets |
+| **[Tree](/docs/js-sdk#custom-crdt-types)** | Node-level merge (via [CRDTTree](#the-tree-crdt)) | Two users add child nodes to the same parent; both nodes appear in deterministic order |
+| **[Counter](/docs/js-sdk#custom-crdt-types)** | Additive merge | Two users increment by 1; the counter increases by 2 |
+
+This means your application does not need to implement any conflict resolution logic. As long as you use Yorkie's data types through `document.update()`, all conflicts are resolved automatically.
+
+### Further Reading
+
+- [Data Structures design document](https://github.com/yorkie-team/yorkie/blob/main/design/data-structure.md) -- Technical details on how Yorkie represents data internally
+- [Garbage Collection design document](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md) -- Deep dive into the GC mechanism
+- [Version Vector design document](https://github.com/yorkie-team/yorkie/blob/main/design/version-vector.md) -- Hybrid logical clock system
+- [Tree design document](https://github.com/yorkie-team/yorkie/blob/main/design/tree.md) -- Tree CRDT for block-based editors
+- [Document Lifecycle](/docs/internals/document-lifecycle) -- States and transitions of documents and clients
+- [JS SDK: Custom CRDT Types](/docs/js-sdk#custom-crdt-types) -- How to use Text, Tree, and Counter in your application
+- [YSON](/docs/internals/yson) -- The serialization format for Yorkie documents
+- [Glossary](/docs/glossary) -- Definitions of all key terms

--- a/docs/internals/document-lifecycle.mdx
+++ b/docs/internals/document-lifecycle.mdx
@@ -1,0 +1,174 @@
+---
+title: 'Document Lifecycle'
+order: 123
+---
+
+## Document Lifecycle
+
+In Yorkie, documents and clients follow a well-defined lifecycle with distinct states and transitions. Understanding this lifecycle helps you design robust collaborative applications that handle all edge cases -- from initial connection through disconnection, reattachment, and deletion.
+
+### Client Lifecycle
+
+A [Client](/docs/js-sdk#client) must be activated before it can work with documents or channels.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Deactivated: new Client()
+    Deactivated --> Activated: activate()
+    Activated --> Deactivated: deactivate()
+    Activated --> Activated: attach/detach documents
+```
+
+| State | Description |
+|-------|-------------|
+| **Deactivated** | The client exists locally but has no connection to the server. No documents can be attached. |
+| **Activated** | The client is registered with the server and can attach to documents and channels. |
+
+When a client is deactivated (via `client.deactivate()` or by the server's [Housekeeping](/docs/glossary) process), all attached documents are detached and resources are released.
+
+### Document States
+
+A document transitions through several states during its lifecycle:
+
+```mermaid
+stateDiagram-v2
+    [*] --> nil
+    nil --> Attaching: attach()
+    Attaching --> Attached: success
+    Attaching --> Attaching: retry on failure
+    Attaching --> Detached: detach()
+    Attaching --> Removed: remove()
+    Attached --> Detached: detach()
+    Attached --> Removed: remove()
+    Detached --> Attaching: attach() (new instance)
+    Removed --> [*]
+```
+
+| State | Description | Allowed Operations |
+|-------|-------------|-------------------|
+| **nil** | No document exists yet for this client. | `attach()` |
+| **Attaching** | The client is attempting to attach to a document. | `attach()` (retry), `detach()`, `remove()` |
+| **Attached** | The document is successfully attached and synchronized. | `update()`, `subscribe()`, `detach()`, `remove()`, `PushPull` |
+| **Detached** | The document has been detached but the client is still active. | `attach()` (with a new Document instance) |
+| **Removed** | The document has been soft-deleted and can no longer be edited. | `deactivate()` |
+
+### Attach and Detach
+
+**Attaching** a document subscribes the client to it, enabling synchronization:
+
+```javascript
+const doc = new yorkie.Document('doc-1');
+await client.attach(doc, {
+  initialPresence: { cursor: { x: 0, y: 0 } },
+});
+// doc is now in "Attached" state
+```
+
+**Detaching** stops synchronization, closes the [Watch Stream](/docs/internals/synchronization#the-watch-stream), and releases resources:
+
+```javascript
+await client.detach(doc);
+// doc is now in "Detached" state
+```
+
+### Reattaching a Document
+
+After a document is detached, you can reattach to the same document key, but you **must create a new Document instance**:
+
+```javascript
+// Correct: create a new instance
+const doc2 = new yorkie.Document('doc-1');
+await client.attach(doc2);
+
+// Incorrect: reusing the detached instance is NOT supported
+// await client.attach(doc); // This will not work
+```
+
+This design ensures [Garbage Collection](/docs/internals/crdt-concepts#garbage-collection) consistency and prevents internal state conflicts. Detached documents are not included in GC calculations, so reattaching a stale instance could leave inconsistent tombstone nodes.
+
+### Document Removal
+
+Documents can be removed (soft-deleted) while in the `Attaching` or `Attached` state:
+
+```javascript
+await client.remove(doc);
+// doc is now in "Removed" state -- no further edits possible
+```
+
+The removal process:
+
+1. The client sends a `RemoveDocument` request to the server.
+2. The server marks the document's `RemovedAt` field with the current time (soft delete).
+3. All other clients are notified that the document is removed.
+4. After a configured period, the [Housekeeping](/docs/glossary) process permanently deletes the document and its data (hard delete).
+
+#### Key-ID Relationship
+
+With document removal and recreation, the relationship between document keys and IDs is **1:N** -- multiple documents can share the same key (representing different versions created at different times). Documents are identified internally by their unique ID, not just their key.
+
+### Document Status Events
+
+Subscribe to document status changes to handle lifecycle transitions in your application:
+
+```javascript
+doc.subscribe('status', (event) => {
+  if (event.value.status === DocStatus.Attached) {
+    // Document is attached and ready for editing
+  } else if (event.value.status === DocStatus.Detached) {
+    // Document has been detached
+  } else if (event.value.status === DocStatus.Removed) {
+    // Document has been removed -- disable editing UI
+  }
+});
+```
+
+### Client Deactivation
+
+When a client is deactivated, all of its documents transition according to their current state:
+
+- **Attached** documents are implicitly detached
+- **Removed** documents remain removed
+- The client moves to the **Deactivated** state
+
+The server's Housekeeping process automatically deactivates clients that have been inactive for longer than the `client-deactivate-threshold` (default: 24 hours). This is important for [Garbage Collection](/docs/internals/crdt-concepts#garbage-collection) -- inactive clients prevent the `minVersionVector` from advancing, blocking GC of tombstoned nodes. By deactivating stale clients, the system can reclaim memory more efficiently.
+
+You can subscribe to connection events to detect when this happens:
+
+```javascript
+doc.subscribe('status', (event) => {
+  if (event.value.status === DocStatus.Detached) {
+    // Client may have been deactivated by the server
+    // Re-activate and reattach if needed
+  }
+});
+```
+
+### PushPull Availability
+
+The `PushPull` synchronization operation is **only available in the Attached state**. This is a key constraint -- you cannot synchronize changes for documents in any other state.
+
+| State | PushPull Available? |
+|-------|-------------------|
+| nil | No |
+| Attaching | No (PushPull runs as part of the attach process) |
+| **Attached** | **Yes** |
+| Detached | No |
+| Removed | No |
+
+### Best Practices
+
+1. **Always check document status** before performing operations, especially after network reconnection.
+2. **Subscribe to status events** to update your UI when documents are detached or removed by external events (server housekeeping, other clients).
+3. **Create new Document instances** when reattaching -- never reuse a detached instance.
+4. **Handle the Removed state** gracefully by disabling editing UI and informing the user.
+5. **Use `client-deactivate-threshold`** appropriately for your use case. Shorter thresholds improve GC efficiency but may deactivate clients on slow or intermittent connections.
+
+### Further Reading
+
+- [Document-Client Lifecycle design document](https://github.com/yorkie-team/yorkie/blob/main/design/document-client-lifecycle.md) -- Full state machine with detailed transitions
+- [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/design/document-editing.md) -- How local and remote editing works internally
+- [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/design/housekeeping.md) -- Client deactivation and document compaction
+- [Synchronization](/docs/internals/synchronization) -- PushPullChanges, checkpoints, and sync modes
+- [CRDT Concepts: Garbage Collection](/docs/internals/crdt-concepts#garbage-collection) -- How GC relates to client lifecycle
+- [JS SDK: Document](/docs/js-sdk#document) -- SDK reference for document operations
+- [Glossary](/docs/glossary) -- Definitions of all key terms

--- a/docs/internals/synchronization.mdx
+++ b/docs/internals/synchronization.mdx
@@ -1,0 +1,265 @@
+---
+title: 'Synchronization'
+order: 122
+---
+
+## Synchronization
+
+Yorkie keeps document replicas consistent across multiple [Clients](/docs/js-sdk#client) through a synchronization system built on top of [CRDTs](/docs/internals/crdt-concepts). This page explains the mechanisms that make synchronization work: sync modes, PushPullChanges, checkpoints, snapshots, and the watch stream.
+
+### Overview
+
+When a [Client](/docs/js-sdk#client) is attached to a [Document](/docs/js-sdk#document), Yorkie maintains a bidirectional communication channel between the client and the [Server](/docs/self-hosted-server). Changes made locally are pushed to the server, and changes from other clients are pulled. The system tracks what each client has seen using [Checkpoints](#checkpoints) and uses [Snapshots](#snapshots) to optimize synchronization for clients that have fallen behind.
+
+```mermaid
+sequenceDiagram
+    participant A as Client A
+    participant S as Yorkie Server
+    participant B as Client B
+
+    A->>S: Push local changes
+    S->>S: Store changes, update checkpoint
+    S->>B: Notify: new changes available
+    B->>S: Pull changes
+    S->>B: Return changes since last checkpoint
+    B->>B: Apply changes to local replica
+```
+
+### How Editing Works Internally
+
+Understanding how Yorkie handles edits internally helps explain the synchronization process. Each Document contains three internal components:
+
+| Component | Role |
+|-----------|------|
+| **Root** | The source of truth -- the actual CRDT data of the document. It can only be updated by applying [Changes](/docs/js-sdk#editing-the-document). |
+| **Clone** | A proxy copy of the Root. When you call `document.update()`, your edits are first applied to the Clone, which generates Changes. If the operation succeeds, the Changes are then applied to the Root. This provides transaction-like safety. |
+| **LocalChanges** | A buffer that stores Changes waiting to be pushed to the server. Changes are applied locally first, then synchronized asynchronously. |
+
+#### Local Editing Flow
+
+When you call `document.update()`:
+
+1. Your edits are applied to the **Clone** (proxy), which generates **Changes**.
+2. The Changes are applied to the **Root** (source of truth).
+3. The Changes are added to the **LocalChanges** buffer.
+4. The Client detects pending changes and pushes them to the Server asynchronously.
+5. The Server stores the changes and notifies other clients via the [Watch Stream](#the-watch-stream).
+
+#### Remote Editing Flow
+
+When another client's changes arrive:
+
+1. The Client receives changes from the Server during a PushPull operation.
+2. The Changes are applied to the local **Root** using CRDT merge rules.
+3. Subscribed event handlers (via `document.subscribe()`) are called with the change events.
+
+This local-first approach means your application remains responsive even with network latency. For the full technical details, see the [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/design/document-editing.md).
+
+### Sync Modes
+
+Yorkie provides four synchronization modes that control how a document syncs with the server. You can change the mode at any time using `client.changeSyncMode()`.
+
+| Mode | Push | Pull | Watch Stream | Use Case |
+|------|------|------|-------------|----------|
+| **`Realtime`** | Automatic | Automatic | Active | Default mode for real-time collaboration |
+| **`RealtimePushOnly`** | Automatic | Disabled | Active | When you want to send changes but not receive others (e.g., a presenter mode) |
+| **`RealtimeSyncOff`** | Disabled | Disabled | Active | Temporarily pause sync while staying aware of connection status |
+| **`Manual`** | Manual only | Manual only | Disconnected | Full control over when sync happens; useful for batch operations |
+
+```javascript
+import { SyncMode } from '@yorkie-js/sdk';
+
+// Start with real-time sync (default)
+await client.attach(doc);
+
+// Switch to push-only
+await client.changeSyncMode(doc, SyncMode.RealtimePushOnly);
+
+// Pause all sync
+await client.changeSyncMode(doc, SyncMode.RealtimeSyncOff);
+
+// Switch to manual mode
+await client.changeSyncMode(doc, SyncMode.Manual);
+await client.sync(doc); // Manually trigger sync
+```
+
+For the full SDK reference, see [Synchronization Modes](/docs/js-sdk#synchronization-modes).
+
+### PushPullChanges
+
+**PushPullChanges** is the core synchronization API that enables bidirectional exchange of [Changes](/docs/js-sdk#editing-the-document) between a client and the server. Each sync cycle involves:
+
+1. **Push**: The client sends its local changes (operations made since the last sync) to the server.
+2. **Server processing**: The server stores the changes, assigns them a server sequence number, and updates the client's [Checkpoint](#checkpoints).
+3. **Pull**: The server returns any changes from other clients that this client hasn't seen yet.
+4. **Local application**: The client applies the received changes to its local replica using CRDT merge rules.
+
+In `Realtime` mode, PushPullChanges is triggered automatically whenever:
+- The client makes a local change (push)
+- The server notifies the client of remote changes via the watch stream (pull)
+
+In `Manual` mode, you trigger it explicitly:
+
+```javascript
+// Manually synchronize changes
+await client.sync(doc);
+```
+
+### Checkpoints
+
+A **Checkpoint** tracks the synchronization state between a client and the server. It consists of two sequence numbers:
+
+| Field | Description |
+|-------|-------------|
+| **ServerSeq** | The latest server sequence number that the client has received. This represents how far the client has caught up with the server's change history. |
+| **ClientSeq** | The latest client sequence number that the server has acknowledged. This represents how many of the client's local changes the server has received. |
+
+Checkpoints enable efficient synchronization by allowing the server to determine exactly which changes a client still needs:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Server
+
+    Note over C: Checkpoint: ServerSeq=5, ClientSeq=3
+    C->>S: Push changes (ClientSeq 4, 5, 6)
+    S->>C: Ack + Pull (ServerSeq 6, 7, 8)
+    Note over C: Checkpoint: ServerSeq=8, ClientSeq=6
+```
+
+Checkpoints are also used by [Garbage Collection](/docs/internals/crdt-concepts#garbage-collection) to determine when tombstoned nodes can be safely removed -- only after all clients have synced past the version where the node was deleted.
+
+### Snapshots
+
+A **Snapshot** is a complete representation of a document's state at a specific point in time. Snapshots optimize synchronization for clients that have fallen significantly behind.
+
+#### When Are Snapshots Used?
+
+Instead of sending a potentially large sequence of individual changes, the server sends a single snapshot when:
+
+- The number of changes a client needs to catch up exceeds the **SnapshotThreshold** (configured per project)
+- A client reconnects after being offline for an extended period
+- The gap between the client's checkpoint and the current server state is too large
+
+#### How Snapshots Work
+
+```mermaid
+sequenceDiagram
+    participant C as Client (offline for a while)
+    participant S as Server
+
+    Note over S: Document has 1000 new changes
+    C->>S: Reconnect, pull from ServerSeq=50
+    Note over S: Gap (950) > SnapshotThreshold
+    S->>C: Send snapshot at ServerSeq=1000
+    Note over C: Replace local state with snapshot
+    C->>C: Fire 'snapshot' event
+```
+
+#### Handling Snapshots in Your Application
+
+When a snapshot event occurs, the document's entire state is replaced. Subscribe to the `snapshot` event to update your UI accordingly:
+
+```javascript
+doc.subscribe((event) => {
+  if (event.type === 'snapshot') {
+    // The entire document has been replaced with a snapshot.
+    // Re-render the full document state from doc.getRoot().
+  }
+});
+```
+
+Snapshot format uses [YSON](/docs/internals/yson) for serialization, supporting all of Yorkie's custom CRDT types.
+
+### The Watch Stream
+
+In `Realtime` sync modes, Yorkie maintains a **watch stream** -- a persistent connection between the client and server, implemented using [gRPC server-side streaming](https://grpc.io/docs/languages/go/basics/#server-side-streaming-rpc).
+
+#### How the Watch Stream Works
+
+The watch stream uses a **PubSub pattern** on the server:
+
+1. When a client calls `WatchDocument`, the server creates a **Subscription** for that client and adds it to a subscriptions map keyed by document.
+2. When changes occur (via PushPull), the server publishes a `DocChanged` event.
+3. The PubSub system delivers the event to all subscriptions watching that document.
+4. Each subscription's event channel sends the event through the gRPC stream to the client.
+
+```mermaid
+sequenceDiagram
+    participant A as Client A
+    participant S as Server (PubSub)
+    participant B as Client B
+
+    A->>S: WatchDocument (subscribe)
+    B->>S: WatchDocument (subscribe)
+    A->>S: PushPull (edit document)
+    S->>S: Publish DocChanged event
+    S->>B: Stream: DocChanged
+    B->>S: PushPull (pull changes)
+```
+
+#### Event Types
+
+The watch stream delivers three types of events:
+
+| Event | Description |
+|-------|-------------|
+| **DocChanged** | The document has been modified by another client. Triggers a pull operation. |
+| **DocWatched** | A new client has started watching the document (came online). |
+| **DocUnwatched** | A client has stopped watching the document (went offline or detached). |
+
+These events power the [Presence](/docs/js-sdk#presence) system, enabling features like showing who's online and tracking cursor positions.
+
+#### Connection Monitoring
+
+You can monitor the watch stream status:
+
+```javascript
+doc.subscribe('connection', (event) => {
+  if (event.value === StreamConnectionStatus.Connected) {
+    // Watch stream is connected
+  } else if (event.value === StreamConnectionStatus.Disconnected) {
+    // Watch stream is disconnected; sync paused
+  }
+});
+```
+
+When the watch stream disconnects, local changes are buffered and pushed once the connection is restored. This is how Yorkie supports offline editing.
+
+For the full PubSub design, see the [PubSub design document](https://github.com/yorkie-team/yorkie/blob/main/design/pub-sub.md).
+
+### Document Compaction
+
+Over time, a document accumulates a large history of individual changes. **Document Compaction** is a server-side process that reduces storage overhead by:
+
+1. Removing old change history that is no longer needed for synchronization.
+2. Creating a new initial change that represents the current document state.
+3. Maintaining document integrity while reducing metadata size.
+
+Compaction is performed by the [Housekeeping](/docs/glossary) background service and only runs on documents that:
+- Have at least a configured minimum number of changes (default: 1000)
+- Are not currently attached to any client
+
+This process is transparent to clients -- they continue to operate normally while compaction runs on the server.
+
+### Synchronization Lifecycle
+
+Here's the complete lifecycle of a document from attachment to detachment. For the full state machine, see [Document Lifecycle](/docs/internals/document-lifecycle).
+
+1. **Attach**: Client calls `client.attach(doc)`. The document is synced from the server and a watch stream is established.
+2. **Edit**: Client makes changes via `doc.update()`. Changes are first applied locally (Root/Clone), then automatically pushed in `Realtime` mode.
+3. **Receive**: Remote changes arrive via the watch stream (`DocChanged` event) and are pulled and merged into the local replica.
+4. **Mode changes**: Application can switch sync modes as needed (e.g., pausing sync during bulk operations).
+5. **Detach**: Client calls `client.detach(doc)`. Final changes are pushed, the watch stream is closed, and resources are released.
+
+### Further Reading
+
+- [Document Lifecycle](/docs/internals/document-lifecycle) -- State transitions of documents and clients
+- [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/design/document-editing.md) -- Root/Clone/LocalChanges architecture
+- [PubSub design document](https://github.com/yorkie-team/yorkie/blob/main/design/pub-sub.md) -- Watch stream implementation
+- [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/design/housekeeping.md) -- Background compaction and cleanup
+- [JS SDK: Synchronization Modes](/docs/js-sdk#synchronization-modes) -- SDK reference for sync mode APIs
+- [JS SDK: Subscribing to Changes](/docs/js-sdk#subscribing-to-changes) -- How to react to local, remote, and snapshot events
+- [CRDT Concepts](/docs/internals/crdt-concepts) -- How CRDTs ensure conflict-free merging
+- [Revisions](/docs/advanced/revisions) -- Saving and restoring document snapshots
+- [Glossary](/docs/glossary) -- Definitions of all key terms

--- a/docs/internals/yson.mdx
+++ b/docs/internals/yson.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'YSON'
-order: 113
+order: 124
 ---
 
 ## YSON

--- a/docs/js-sdk.mdx
+++ b/docs/js-sdk.mdx
@@ -396,7 +396,7 @@ When the `event.type` is `local-change` or `remote-change`, the `event.value` is
 For more information about changeInfo for document events, please refer to the [ChangeInfo](https://yorkie.dev/yorkie-js-sdk/api-reference/interfaces/ChangeInfo.html).
 
 <Alert status="warning">
-The `event.rawChange` value for `local-change` and `remote-change` events, and the `event.value.snapshot` for `snapshot` event, are set only when [`enableDevtools`](/docs/devtools/#install-the-extension) option is configured as `true`.
+The `event.rawChange` value for `local-change` and `remote-change` events, and the `event.value.snapshot` for `snapshot` event, are set only when [`enableDevtools`](/docs/tools/devtools/#install-the-extension) option is configured as `true`.
 </Alert>
 
 The `snapshot` event occurs when the number of changes to fetch from the server exceeds `SnapshotThreshold`. The server sends a complete snapshot instead of individual changes. See this [example code](https://github.com/yorkie-team/yorkie-js-sdk/blob/9c7accdfe337b9c9e7c7d0d3b3acc335951866ce/public/index.html#L346-L350) for handling snapshots in CodeMirror.
@@ -468,7 +468,7 @@ const unsubscribe = doc.subscribe('status', (event) => {
 For more information about `DocStatus`, please refer to the [DocStatus](https://yorkie.dev/yorkie-js-sdk/api-reference/enums/DocStatus.html).
 
 <Alert status="warning">
-In web applications, detecting browser closure or navigation is difficult. Yorkie's `client-deactivate-threshold` automatically deactivates inactive clients, triggering a `DocumentStatus.Detached` event. See [Client Deactivate Threshold](/docs/cli#client-deactivate-threshold).
+In web applications, detecting browser closure or navigation is difficult. Yorkie's `client-deactivate-threshold` automatically deactivates inactive clients, triggering a `DocumentStatus.Detached` event. See [Client Deactivate Threshold](/docs/tools/cli#client-deactivate-threshold).
 </Alert>
 
 **Document.subscribe('auth-error')**
@@ -489,7 +489,7 @@ For more information about `Auth Webhook`, please refer to the [Auth Webhook](/d
 
 **Document.subscribe('all')**
 
-Subscribe to all document events. Used for [Devtools extension](/docs/devtools).
+Subscribe to all document events. Used for [Devtools extension](/docs/tools/devtools).
 
 ```javascript
 const unsubscribe = doc.subscribe('all', (transactionEvent) => {
@@ -701,7 +701,7 @@ console.log('Revision data:', snapshot);
 
 The returned revision object contains:
 - All metadata from the revision summary
-- `snapshot`: document state at the time of the revision, [YSON](/docs/advanced/yson) representation
+- `snapshot`: document state at the time of the revision, [YSON](/docs/internals/yson) representation
 
 <Alert status="info">
 The snapshot contains the full document data as it existed when the revision was created. This data can be used for comparison, preview, or restoration purposes.
@@ -964,7 +964,7 @@ When using hierarchical channel keys, follow these rules:
 | Cannot end with a period | ❌ `room-1.`<br/>❌ `room-1.section-1.` | ✅ `room-1`<br/>✅ `room-1.section-1` |
 | Cannot contain consecutive periods | ❌ `room-1..section-1`<br/>❌ `room..section..subsection` | ✅ `room-1.section-1`<br/>✅ `room.section.subsection` |
 
-**Query channel information:** Use the [GetChannels API](/docs/admin-api#post-yorkiev1adminservicegetchannels) to retrieve presence counts for specific channels and their sub-levels.
+**Query channel information:** Use the [GetChannels API](/docs/tools/admin-api#post-yorkiev1adminservicegetchannels) to retrieve presence counts for specific channels and their sub-levels.
 
 <Alert status="warning">
 **Important: Distribute First-Level Channel Keys**

--- a/docs/js-sdk/react.mdx
+++ b/docs/js-sdk/react.mdx
@@ -102,7 +102,7 @@ Set `userID` in the `metadata` prop to measure Monthly Active Users. The `userID
 | docKey | string | Yes | - | Unique document key |
 | initialRoot | `Record<string, any>` | No | {} | Initial values for the document root |
 | initialPresence | `Record<string, any>` | No | {} | Initial presence data for the current client |
-| enableDevtools | boolean | No | false | Enable [Devtools](/docs/devtools) integration |
+| enableDevtools | boolean | No | false | Enable [Devtools](/docs/tools/devtools) integration |
 
 **Basic usage:**
 
@@ -157,7 +157,7 @@ Set initial presence data that will be shared with other participants:
 
 **enableDevtools:**
 
-Enable the [Devtools](/docs/devtools) extension for debugging document state:
+Enable the [Devtools](/docs/tools/devtools) extension for debugging document state:
 
 ```tsx
 <DocumentProvider docKey="my-doc" enableDevtools={true}>

--- a/docs/self-hosted-server.mdx
+++ b/docs/self-hosted-server.mdx
@@ -7,7 +7,7 @@ order: 100
 
 This page explains how to run your own Yorkie Server.
 
-To run a Yorkie Server, you need to install the CLI. If you haven't installed it yet, please refer to [CLI](/docs/cli).
+To run a Yorkie Server, you need to install the CLI. If you haven't installed it yet, please refer to [CLI](/docs/tools/cli).
 
 ### Running a Server via CLI
 

--- a/docs/self-hosted-server/aws-eks.mdx
+++ b/docs/self-hosted-server/aws-eks.mdx
@@ -174,7 +174,7 @@ yorkie-gateway-d8cbfd477-swnfr                   1/1     Running     0          
 
 ### Test Yorkie cluster
 
-Now that Yorkie cluster is exposed, you can test Yorkie cluster with [Yorkie CLI](/docs/cli).
+Now that Yorkie cluster is exposed, you can test Yorkie cluster with [Yorkie CLI](/docs/tools/cli).
 
 ```bash
 $ yorkie login -u admin -p admin --rpc-addr http://<YOUR_API_DOMAIN_NAME or IP_ADDRESS>

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -209,7 +209,7 @@ $ minikube ip
 
 ### Test Yorkie cluster
 
-Now that Yorkie cluster is exposed, you can test Yorkie cluster with [Yorkie CLI](/docs/cli).
+Now that Yorkie cluster is exposed, you can test Yorkie cluster with [Yorkie CLI](/docs/tools/cli).
 
 ```bash
 $ yorkie login -u admin -p admin --insecure --rpc-addr localhost

--- a/docs/tools.mdx
+++ b/docs/tools.mdx
@@ -1,0 +1,21 @@
+---
+title: 'Tools & APIs'
+order: 60
+---
+
+## Tools & APIs
+
+This section covers the developer tools and APIs for managing, debugging, and integrating with Yorkie beyond the client SDKs.
+
+### Topics
+
+- **[Devtools](/docs/tools/devtools)**: Browser extension for inspecting and debugging Yorkie documents, presence, and events in real time
+- **[CLI](/docs/tools/cli)**: Command-line interface for managing projects, documents, and server configuration
+- **[Admin API](/docs/tools/admin-api)**: REST API for programmatic document and project management from server-side applications
+- **[MCP](/docs/tools/mcp)**: Model Context Protocol server for integrating Yorkie with AI assistants and LLM-based tools
+
+### Prerequisites
+
+Before exploring these topics, ensure you have:
+1. Completed the [Getting Started guide](/docs/getting-started)
+2. Understood basic concepts like [Client](/docs/js-sdk#client), [Document](/docs/js-sdk#document), and [Channel](/docs/js-sdk#channel)

--- a/docs/tools/admin-api.mdx
+++ b/docs/tools/admin-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Admin API'
-order: 90
+order: 63
 ---
 
 ## Admin API
@@ -33,7 +33,7 @@ This endpoint creates a new document in the specified project. If `initial_root`
 Parameters:
 
 - `document_key`: A unique key for the new document.
-- `initial_root`: The initial root([YSON string](/docs/advanced/yson)) of the document.
+- `initial_root`: The initial root([YSON string](/docs/internals/yson)) of the document.
 
 ```bash
 curl '{{API_ADDR}}/yorkie.v1.AdminService/CreateDocument' \
@@ -69,7 +69,7 @@ This endpoint updates the content of an existing document.
 Parameters:
 
 - `document_key`: The key of the document to update.
-- `root`: The new root content ([YSON string](/docs/advanced/yson)) of the document.
+- `root`: The new root content ([YSON string](/docs/internals/yson)) of the document.
 
 ```bash
 curl '{{API_ADDR}}/yorkie.v1.AdminService/UpdateDocument' \

--- a/docs/tools/cli.mdx
+++ b/docs/tools/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'CLI'
-order: 70
+order: 62
 ---
 
 ## CLI

--- a/docs/tools/devtools.mdx
+++ b/docs/tools/devtools.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Devtools'
-order: 60
+order: 61
 ---
 
 ## Devtools

--- a/docs/tools/mcp.mdx
+++ b/docs/tools/mcp.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'MCP'
-order: 95
-phase: development
+order: 64
 ---
 
 ## MCP (Model Context Protocol)
@@ -45,7 +44,7 @@ The MCP service runs alongside the existing Yorkie and Admin services, sharing t
 #### Prerequisites
 
 Before using MCP, ensure you have:
-1. A Yorkie project with a secret key (from [Dashboard]({{DASHBOARD_PATH}}) or via the [Admin API](/docs/admin-api))
+1. A Yorkie project with a secret key (from [Dashboard]({{DASHBOARD_PATH}}) or via the [Admin API](/docs/tools/admin-api))
 2. An MCP-compatible AI assistant (e.g., Claude Desktop)
 
 #### Claude Desktop Configuration
@@ -80,7 +79,7 @@ Claude should list the available MCP tools for document inspection, schema manag
 
 ### Authentication
 
-MCP uses the same API key authentication as the [Admin API](/docs/admin-api):
+MCP uses the same API key authentication as the [Admin API](/docs/tools/admin-api):
 
 ```
 Authorization: API-Key <project-secret-key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
       "version": "7.19.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
       "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -1853,7 +1854,8 @@
     "node_modules/@bufbuild/protobuf": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.10.1.tgz",
-      "integrity": "sha512-ckS3+vyJb5qGpEYv/s1OebUHDi/xSNtfgw1wqKZo7MR9F2z+qXr0q5XagafAG/9O0QPVIUfST0smluYSTpYFkg=="
+      "integrity": "sha512-ckS3+vyJb5qGpEYv/s1OebUHDi/xSNtfgw1wqKZo7MR9F2z+qXr0q5XagafAG/9O0QPVIUfST0smluYSTpYFkg==",
+      "peer": true
     },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "11.0.3",
@@ -1910,6 +1912,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -2116,7 +2119,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
       "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -2127,7 +2129,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
       "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2692,6 +2693,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.5.0.tgz",
       "integrity": "sha512-jIbu36GMjfK8HCCQitkfVVeQ2vSXGfq0ef0GO9HUxZGjal6Kvpkk4PwpkFP+OyCzF+skQFT9aWrUqekT3pKF8w==",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.18.5",
         "@svgr/babel-preset": "^6.5.0",
@@ -3100,7 +3102,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
       "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3111,7 +3112,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
       "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -3153,8 +3153,7 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3205,7 +3204,8 @@
       "version": "18.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.5.tgz",
       "integrity": "sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -3359,7 +3359,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
       "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -3369,29 +3368,25 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
       "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
       "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
       "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
       "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -3402,15 +3397,13 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
       "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
       "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -3423,7 +3416,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
       "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -3433,7 +3425,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
       "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -3442,15 +3433,13 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
       "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
       "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -3467,7 +3456,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
       "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -3481,7 +3469,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
       "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -3494,7 +3481,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
       "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -3509,7 +3495,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
       "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
@@ -3519,15 +3504,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@yorkie-js/schema": {
       "version": "0.6.44",
@@ -3569,6 +3552,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3581,7 +3565,6 @@
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -3611,6 +3594,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3627,7 +3611,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
@@ -3957,6 +3940,7 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -3997,8 +3981,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -4193,7 +4176,6 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -4448,6 +4430,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4860,6 +4843,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5237,7 +5221,6 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
       "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -5307,8 +5290,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.0",
@@ -5366,6 +5348,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
       "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.11.6",
@@ -5555,6 +5538,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -6013,7 +5997,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -6419,8 +6402,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -6483,8 +6465,7 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -7161,7 +7142,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -7176,7 +7156,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7368,7 +7347,6 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       }
@@ -7767,8 +7745,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -8631,13 +8608,13 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/next": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/next/-/next-13.0.0.tgz",
       "integrity": "sha512-puH1WGM6rGeFOoFdXXYfUxN9Sgi4LMytCV5HkQJvVUOhHfC1DoVqOfvzaEteyp6P04IW+gbtK2Q9pInVSrltPA==",
+      "peer": true,
       "dependencies": {
         "@next/env": "13.0.0",
         "@swc/helpers": "0.4.11",
@@ -9457,7 +9434,6 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -9510,6 +9486,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9521,6 +9498,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -9898,6 +9876,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
       "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -9923,7 +9902,6 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
       "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -10009,7 +9987,6 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -10175,7 +10152,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -10432,7 +10408,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10468,7 +10443,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
       "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -10487,7 +10461,6 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
       "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
@@ -10521,8 +10494,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -10736,6 +10708,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11141,7 +11114,6 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
       "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -11155,7 +11127,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
       "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -11203,7 +11174,6 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -11212,15 +11182,13 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -11234,7 +11202,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -11364,6 +11331,7 @@
       "version": "7.19.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
       "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -12553,7 +12521,8 @@
     "@bufbuild/protobuf": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.10.1.tgz",
-      "integrity": "sha512-ckS3+vyJb5qGpEYv/s1OebUHDi/xSNtfgw1wqKZo7MR9F2z+qXr0q5XagafAG/9O0QPVIUfST0smluYSTpYFkg=="
+      "integrity": "sha512-ckS3+vyJb5qGpEYv/s1OebUHDi/xSNtfgw1wqKZo7MR9F2z+qXr0q5XagafAG/9O0QPVIUfST0smluYSTpYFkg==",
+      "peer": true
     },
     "@chevrotain/cst-dts-gen": {
       "version": "11.0.3",
@@ -12607,6 +12576,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
+      "peer": true,
       "requires": {}
     },
     "@connectrpc/connect-web": {
@@ -12777,7 +12747,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
       "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -12788,7 +12757,6 @@
           "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
           "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
           "dev": true,
-          "peer": true,
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -13121,6 +13089,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.5.0.tgz",
       "integrity": "sha512-jIbu36GMjfK8HCCQitkfVVeQ2vSXGfq0ef0GO9HUxZGjal6Kvpkk4PwpkFP+OyCzF+skQFT9aWrUqekT3pKF8w==",
+      "peer": true,
       "requires": {
         "@babel/core": "^7.18.5",
         "@svgr/babel-preset": "^6.5.0",
@@ -13454,7 +13423,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
       "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -13465,7 +13433,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
       "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -13506,8 +13473,7 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -13558,7 +13524,8 @@
       "version": "18.11.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.5.tgz",
       "integrity": "sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -13663,7 +13630,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
       "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/helper-numbers": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -13673,29 +13639,25 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
       "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
       "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
       "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
       "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -13706,15 +13668,13 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
       "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
       "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -13727,7 +13687,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
       "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -13737,7 +13696,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
       "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
@@ -13746,15 +13704,13 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
       "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
       "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -13771,7 +13727,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
       "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -13785,7 +13740,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
       "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -13798,7 +13752,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
       "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -13813,7 +13766,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
       "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
@@ -13823,15 +13775,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@yorkie-js/schema": {
       "version": "0.6.44",
@@ -13862,14 +13812,14 @@
     "acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "acorn-jsx": {
@@ -13892,6 +13842,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13904,7 +13855,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "ansi-regex": {
@@ -14144,6 +14094,7 @@
       "version": "4.21.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
       "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -14164,8 +14115,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "bytes": {
       "version": "3.1.2",
@@ -14292,8 +14242,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "classnames": {
       "version": "2.3.2",
@@ -14486,7 +14435,8 @@
     "cytoscape": {
       "version": "3.33.1",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ=="
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "peer": true
     },
     "cytoscape-cose-bilkent": {
       "version": "4.1.0",
@@ -14774,7 +14724,8 @@
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true
     },
     "d3-shape": {
       "version": "3.2.0",
@@ -15038,7 +14989,6 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
       "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -15093,8 +15043,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "es-shim-unscopables": {
       "version": "1.0.0",
@@ -15137,6 +15086,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
       "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.11.6",
@@ -15311,6 +15261,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -15637,8 +15588,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "expand-template": {
       "version": "2.0.3",
@@ -15986,8 +15936,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "globals": {
       "version": "13.17.0",
@@ -16016,8 +15965,7 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -16473,7 +16421,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -16485,7 +16432,6 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -16633,8 +16579,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
@@ -16928,8 +16873,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -17460,13 +17404,13 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "next": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/next/-/next-13.0.0.tgz",
       "integrity": "sha512-puH1WGM6rGeFOoFdXXYfUxN9Sgi4LMytCV5HkQJvVUOhHfC1DoVqOfvzaEteyp6P04IW+gbtK2Q9pInVSrltPA==",
+      "peer": true,
       "requires": {
         "@next/env": "13.0.0",
         "@next/swc-android-arm-eabi": "13.0.0",
@@ -18035,7 +17979,6 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -18078,6 +18021,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -18086,6 +18030,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -18352,6 +18297,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
       "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "devOptional": true,
+      "peer": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -18371,7 +18317,6 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
       "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -18442,7 +18387,6 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
-      "peer": true,
       "requires": {
         "randombytes": "^2.1.0"
       }
@@ -18554,7 +18498,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -18743,8 +18686,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "tar-fs": {
       "version": "2.1.1",
@@ -18774,7 +18716,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
       "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -18786,8 +18727,7 @@
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -18796,7 +18736,6 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
       "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
@@ -18948,7 +18887,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "ufo": {
       "version": "1.6.3",
@@ -19222,7 +19162,6 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
       "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -19233,7 +19172,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
       "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -19265,15 +19203,13 @@
           "version": "0.0.51",
           "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
           "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "eslint-scope": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
           "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
           "dev": true,
-          "peer": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^4.1.1"
@@ -19283,8 +19219,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
           "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -19292,8 +19227,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "which": {
       "version": "2.0.2",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Reorganize docs into Tools & APIs, Configuration, and Internals groups

Split the navigation into clearer groups:
- Tools & APIs (order 60): Devtools, CLI, Admin API, MCP
- Configuration (order 110): Architecture Patterns, Security, Event Webhook, Revisions, Resources, Projects
- Internals (order 120): CRDT Concepts, Synchronization, Document Lifecycle, YSON, Cluster Mode

Also adds new pages (Projects, CRDT Concepts, Synchronization, Document Lifecycle, Cluster Mode) and enriches the Glossary with additional terms and cross-links.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Reorganized documentation structure into Tools, Advanced Configuration, and Internals sections for improved navigation
* Added comprehensive guides for Projects, Cluster Mode, CRDT Concepts, Document Lifecycle, and Synchronization
* Expanded Glossary with new linked terms and detailed definitions
* Updated internal documentation links across all pages to reflect new structure
* Enhanced Advanced Configuration section with Event Webhook documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->