### PR TITLE
Fix mermaid edge comments visibility

### DIFF
--- a/styles/components/_mermaid.scss
+++ b/styles/components/_mermaid.scss
@@ -106,6 +106,7 @@
       color: var(--gray-100);
 
       .labelBkg {
+        background-color: var(--gray-800);
         color: inherit;
       }
 

--- a/styles/components/_mermaid.scss
+++ b/styles/components/_mermaid.scss
@@ -17,7 +17,7 @@
   .node circle,
   .node ellipse,
   .node polygon {
-    fill: var(--white);
+    fill: var(--gray-000);
     stroke: var(--gray-400);
     stroke-width: 2px;
   }
@@ -28,9 +28,40 @@
   }
 
   .edgeLabel {
-    background-color: var(--white);
+    background-color: var(--gray-000);
     padding: 4px 8px;
     border-radius: 4px;
+    color: #332e2b;
+
+    foreignObject {
+      overflow: visible;
+
+      & > div {
+        width: max-content;
+        height: max-content;
+        margin: 0 auto;
+        padding: 0;
+        line-height: 1.2;
+        
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+      }
+    }
+
+    p,
+    span {
+      margin: 0;
+      padding: 0;
+      line-height: 1.2;
+      color: inherit;
+    }
+
+    .labelBkg {
+      background-color: var(--gray-000);
+      color: inherit;
+    }
   }
 
   text {
@@ -39,7 +70,7 @@
   }
 
   .actor {
-    fill: var(--white);
+    fill: var(--gray-000);
     stroke: var(--gray-400);
   }
 
@@ -49,7 +80,7 @@
   }
 
   .labelBox {
-    fill: var(--white);
+    fill: var(--gray-000);
     stroke: var(--gray-400);
   }
 }

--- a/styles/components/_mermaid.scss
+++ b/styles/components/_mermaid.scss
@@ -31,7 +31,7 @@
     background-color: var(--gray-000);
     padding: 4px 8px;
     border-radius: 4px;
-    color: #332e2b;
+    color: var(--gray-900);
 
     foreignObject {
       overflow: visible;
@@ -103,13 +103,14 @@
 
     .edgeLabel {
       background-color: var(--gray-800);
+      color: var(--gray-100);
 
       .labelBkg {
-        color: var(--gray-100);
+        color: inherit;
       }
 
       p {
-        color: var(--gray-100);
+        color: inherit;
         margin: 0;
       }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR fixes mermaid edge comments visibility.
<img width="1100" height="350" alt="image" src="https://github.com/user-attachments/assets/a85e805c-23df-4f0d-986c-e1d87c13365d" />


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated Mermaid diagram colors to a neutral gray palette for nodes, actors and label backgrounds to improve visual consistency.
  * Enhanced edge label styling and layout (backgrounds, text color, sizing and wrapping) for better readability, including adjusted colors for dark theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->