### PR TITLE
Bump up Yorkie to v0.7.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 # Common Environment Variables
-NEXT_PUBLIC_YORKIE_VERSION='0.7.0'
-NEXT_PUBLIC_YORKIE_JS_VERSION='0.7.0'
+NEXT_PUBLIC_YORKIE_VERSION='0.7.1'
+NEXT_PUBLIC_YORKIE_JS_VERSION='0.7.1'
 NEXT_PUBLIC_YORKIE_IOS_VERSION='0.6.35'
 NEXT_PUBLIC_YORKIE_ANDROID_VERSION='0.6.35'
 NEXT_PUBLIC_DASHBOARD_PATH='/dashboard'
-NEXT_PUBLIC_JS_SDK_URL='https://cdn.jsdelivr.net/npm/@yorkie-js/sdk@0.7.0/dist/yorkie-js-sdk.js'
+NEXT_PUBLIC_JS_SDK_URL='https://cdn.jsdelivr.net/npm/@yorkie-js/sdk@0.7.1/dist/yorkie-js-sdk.js'
 NEXT_PUBLIC_STATUS_URL='https://stats.uptimerobot.com/otOOggryMR'
 
 # Development Environment Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@jsdevtools/rehype-toc": "^3.0.2",
         "@svgr/webpack": "^6.5.0",
-        "@yorkie-js/sdk": "^0.7.0",
+        "@yorkie-js/sdk": "^0.7.1",
         "classnames": "^2.3.2",
         "framer-motion": "^7.6.7",
         "gray-matter": "^4.0.3",
@@ -3530,19 +3530,20 @@
       "peer": true
     },
     "node_modules/@yorkie-js/schema": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.0.tgz",
-      "integrity": "sha512-OUboi0oL40pfxObQiIUCni3OAME98aSjGAbsqCv47pw33GTt0MJQAnCLTn7Q3T4QhvTIgRDFNu3IiwdyliF4+Q=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.1.tgz",
+      "integrity": "sha512-r/XR+M1lerJg3+AbCfKugsKz4ZNkp0aeP+d/5AMYfZQClyt7V0dj4RXTmGhhSpbzR9JjExmOKg7Ro2OIQ8YiUw=="
     },
     "node_modules/@yorkie-js/sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.0.tgz",
-      "integrity": "sha512-m2njYJh+JLZl4mx6UqD5+DLohaP3AohzhYKBL68IPtEuAs6qTm3RLzeUs5nY8ri+odyD06CIAeCoQe+5Kk9Ufg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.1.tgz",
+      "integrity": "sha512-p9Wgt4Oml5Q3INZD5g6fpWntcoD1gBKW6VdlCisH5j9x6PiCtzJ2IWTWR+337O01+Z2m3I4xsF8x4fEipnNPyQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.1",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
-        "@yorkie-js/schema": "0.7.0",
+        "@yorkie-js/schema": "0.7.1",
         "long": "^5.3.2"
       },
       "engines": {
@@ -13833,19 +13834,19 @@
       "peer": true
     },
     "@yorkie-js/schema": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.0.tgz",
-      "integrity": "sha512-OUboi0oL40pfxObQiIUCni3OAME98aSjGAbsqCv47pw33GTt0MJQAnCLTn7Q3T4QhvTIgRDFNu3IiwdyliF4+Q=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/schema/-/schema-0.7.1.tgz",
+      "integrity": "sha512-r/XR+M1lerJg3+AbCfKugsKz4ZNkp0aeP+d/5AMYfZQClyt7V0dj4RXTmGhhSpbzR9JjExmOKg7Ro2OIQ8YiUw=="
     },
     "@yorkie-js/sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.0.tgz",
-      "integrity": "sha512-m2njYJh+JLZl4mx6UqD5+DLohaP3AohzhYKBL68IPtEuAs6qTm3RLzeUs5nY8ri+odyD06CIAeCoQe+5Kk9Ufg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.1.tgz",
+      "integrity": "sha512-p9Wgt4Oml5Q3INZD5g6fpWntcoD1gBKW6VdlCisH5j9x6PiCtzJ2IWTWR+337O01+Z2m3I4xsF8x4fEipnNPyQ==",
       "requires": {
         "@bufbuild/protobuf": "^2.10.1",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
-        "@yorkie-js/schema": "0.7.0",
+        "@yorkie-js/schema": "0.7.1",
         "long": "^5.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@jsdevtools/rehype-toc": "^3.0.2",
     "@svgr/webpack": "^6.5.0",
-    "@yorkie-js/sdk": "^0.7.0",
+    "@yorkie-js/sdk": "^0.7.1",
     "classnames": "^2.3.2",
     "framer-motion": "^7.6.7",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary
- Bump @yorkie-js/sdk to ^0.7.1
- Update NEXT_PUBLIC_YORKIE_VERSION and NEXT_PUBLIC_YORKIE_JS_VERSION to 0.7.1
- Update NEXT_PUBLIC_JS_SDK_URL to @yorkie-js/sdk@0.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Yorkie JavaScript SDK to the latest patch version with improvements and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->