### PR TITLE
Bump Yorkie JS SDK to v0.7.2

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 # Common Environment Variables
-NEXT_PUBLIC_YORKIE_VERSION='0.7.1'
-NEXT_PUBLIC_YORKIE_JS_VERSION='0.7.1'
+NEXT_PUBLIC_YORKIE_VERSION='0.7.2'
+NEXT_PUBLIC_YORKIE_JS_VERSION='0.7.2'
 NEXT_PUBLIC_YORKIE_IOS_VERSION='0.6.35'
 NEXT_PUBLIC_YORKIE_ANDROID_VERSION='0.6.35'
 NEXT_PUBLIC_DASHBOARD_PATH='/dashboard'
-NEXT_PUBLIC_JS_SDK_URL='https://cdn.jsdelivr.net/npm/@yorkie-js/sdk@0.7.1/dist/yorkie-js-sdk.js'
+NEXT_PUBLIC_JS_SDK_URL='https://cdn.jsdelivr.net/npm/@yorkie-js/sdk@0.7.2/dist/yorkie-js-sdk.js'
 NEXT_PUBLIC_STATUS_URL='https://stats.uptimerobot.com/otOOggryMR'
 
 # Development Environment Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@jsdevtools/rehype-toc": "^3.0.2",
         "@svgr/webpack": "^6.5.0",
-        "@yorkie-js/sdk": "^0.7.1",
+        "@yorkie-js/sdk": "^0.7.2",
         "classnames": "^2.3.2",
         "framer-motion": "^7.6.7",
         "gray-matter": "^4.0.3",
@@ -3535,9 +3535,9 @@
       "integrity": "sha512-r/XR+M1lerJg3+AbCfKugsKz4ZNkp0aeP+d/5AMYfZQClyt7V0dj4RXTmGhhSpbzR9JjExmOKg7Ro2OIQ8YiUw=="
     },
     "node_modules/@yorkie-js/sdk": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.1.tgz",
-      "integrity": "sha512-p9Wgt4Oml5Q3INZD5g6fpWntcoD1gBKW6VdlCisH5j9x6PiCtzJ2IWTWR+337O01+Z2m3I4xsF8x4fEipnNPyQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.2.tgz",
+      "integrity": "sha512-8rH2sqwGslKPo0igyQi1NSkPurmEy0S5A8GLVceRu1EoprNkzAia8/64qng9+GnB6H4aoQCH9DKW+ggVK1uFAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.1",
@@ -13839,9 +13839,9 @@
       "integrity": "sha512-r/XR+M1lerJg3+AbCfKugsKz4ZNkp0aeP+d/5AMYfZQClyt7V0dj4RXTmGhhSpbzR9JjExmOKg7Ro2OIQ8YiUw=="
     },
     "@yorkie-js/sdk": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.1.tgz",
-      "integrity": "sha512-p9Wgt4Oml5Q3INZD5g6fpWntcoD1gBKW6VdlCisH5j9x6PiCtzJ2IWTWR+337O01+Z2m3I4xsF8x4fEipnNPyQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@yorkie-js/sdk/-/sdk-0.7.2.tgz",
+      "integrity": "sha512-8rH2sqwGslKPo0igyQi1NSkPurmEy0S5A8GLVceRu1EoprNkzAia8/64qng9+GnB6H4aoQCH9DKW+ggVK1uFAQ==",
       "requires": {
         "@bufbuild/protobuf": "^2.10.1",
         "@connectrpc/connect": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@jsdevtools/rehype-toc": "^3.0.2",
     "@svgr/webpack": "^6.5.0",
-    "@yorkie-js/sdk": "^0.7.1",
+    "@yorkie-js/sdk": "^0.7.2",
     "classnames": "^2.3.2",
     "framer-motion": "^7.6.7",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary
- Update `@yorkie-js/sdk` to `^0.7.2` in package.json
- Update `VITE_JS_SDK_VERSION` to `0.7.2` in .env
- Update dashboard version to `0.7.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Yorkie JavaScript SDK to version 0.7.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->