### PR TITLE
Add minimum resource requirements for minikube setup

### DIFF
--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -31,9 +31,7 @@ Start Minikube with the following command. The yorkie-cluster Helm chart deploys
 $ minikube start --cpus=4 --memory=8192 --driver=docker
 ```
 
-:::note
-The default minikube resource settings (2 CPUs, 2GB memory) are insufficient for running the full Yorkie cluster. If you encounter pod scheduling failures or OOMKilled errors, ensure your minikube instance has at least 4 CPUs and 8GB of memory.
-:::
+<Alert status="info">The default minikube resource settings (2 CPUs, 2GB memory) are insufficient for running the full Yorkie cluster. If you encounter pod scheduling failures or OOMKilled errors, ensure your minikube instance has at least 4 CPUs and 8GB of memory.</Alert>
 
 After Minikube is started, you will see the following output:
 

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -25,11 +25,15 @@ For this tutorial, you will need:
 
 First, you need to setup minikube on your machine to use Kubernetes locally and deploy Yorkie cluster.
 
-Start Minikube with the following command:
+Start Minikube with the following command. The yorkie-cluster Helm chart deploys a Percona MongoDB sharded cluster (config server, 2 shards, mongos), 3 Yorkie replicas, and an Istio gateway, so you need to allocate sufficient CPU and memory resources:
 
 ```bash
-$ minikube start
+$ minikube start --cpus=4 --memory=8192 --driver=docker
 ```
+
+:::note
+The default minikube resource settings (2 CPUs, 2GB memory) are insufficient for running the full Yorkie cluster. If you encounter pod scheduling failures or OOMKilled errors, ensure your minikube instance has at least 4 CPUs and 8GB of memory.
+:::
 
 After Minikube is started, you will see the following output:
 


### PR DESCRIPTION
## Summary
- Update `minikube start` command to specify `--cpus=4 --memory=8192 --driver=docker`
- Add a note explaining why these resources are needed

## Context
Fresh installs of the yorkie-cluster Helm chart on minikube fail with default resource settings (2 CPUs, 2GB memory). The chart deploys a Percona MongoDB sharded cluster (config server, 2 shards, mongos), 3 Yorkie replicas, and an Istio gateway, which together require at least 4 CPUs and 8GB of memory. Without specifying these minimums, users encounter pod scheduling failures and OOMKilled errors.

## Test plan
- [x] Verify the documentation page renders correctly (Docusaurus note admonition syntax)
- [x] Confirm a fresh `minikube start --cpus=4 --memory=8192 --driver=docker` followed by the Helm install completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Minikube startup command to recommend Docker driver and explicit resources (4 CPUs, 8GB memory).
  * Added guidance on increasing Minikube resources when encountering scheduling failures or OOMKilled events.
  * Described the deployment workload footprint (database shards, Yorkie replicas, ingress) so users can size their local cluster accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->