### PR TITLE
Bump Yorkie to v0.7.4

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 # Common Environment Variables
-NEXT_PUBLIC_YORKIE_VERSION='0.7.3'
-NEXT_PUBLIC_YORKIE_JS_VERSION='0.7.3'
+NEXT_PUBLIC_YORKIE_VERSION='0.7.4'
+NEXT_PUBLIC_YORKIE_JS_VERSION='0.7.4'
 NEXT_PUBLIC_YORKIE_IOS_VERSION='0.6.35'
 NEXT_PUBLIC_YORKIE_ANDROID_VERSION='0.6.35'
 NEXT_PUBLIC_DASHBOARD_PATH='/dashboard'
-NEXT_PUBLIC_JS_SDK_URL='https://cdn.jsdelivr.net/npm/@yorkie-js/sdk@0.7.3/dist/yorkie-js-sdk.js'
+NEXT_PUBLIC_JS_SDK_URL='https://cdn.jsdelivr.net/npm/@yorkie-js/sdk@0.7.4/dist/yorkie-js-sdk.js'
 NEXT_PUBLIC_STATUS_URL='https://stats.uptimerobot.com/otOOggryMR'
 
 # Development Environment Variables


### PR DESCRIPTION
## Summary
- Update `NEXT_PUBLIC_YORKIE_VERSION` to `0.7.4`
- Update `NEXT_PUBLIC_YORKIE_JS_VERSION` to `0.7.4`
- Update `NEXT_PUBLIC_JS_SDK_URL` to `@yorkie-js/sdk@0.7.4`

## Test plan
- [x] `npm run build` passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded application to use SDK version 0.7.4 to leverage latest improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->