### PR TITLE
Document Counter dedup mode for UV measurement

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -29,7 +29,7 @@ These terms are used in the Yorkie project and community. Understanding them wil
 | [YSON](/docs/internals/yson) | Yorkie JSON (YSON) is a JSON-like format for representing Yorkie documents, including custom CRDT types such as `Text`, `Tree`, `Counter`, along with specialized types like `Int`, `Long`, `Date`, and `BinData`. Used for document snapshots and serialization. |
 | [Text](/docs/sdks/js-sdk#custom-crdt-types) | A list-based CRDT type for collaborative rich text editing. Supports styling attributes and cursor sharing via presence. Used for integrations like [Quill](/examples/quill) and [CodeMirror](/examples/codemirror). |
 | [Tree](/docs/sdks/js-sdk#custom-crdt-types) | A tree-based CRDT type for structured rich text editing. Represents content as a hierarchical tree of nodes, similar to a DOM structure. |
-| [Counter](/docs/sdks/js-sdk#custom-crdt-types) | A CRDT type for concurrent counting operations. Supports integer and long types, allowing multiple users to increment or decrement a value simultaneously without conflicts. |
+| [Counter](/docs/sdks/js-sdk#custom-crdt-types) | A CRDT type for concurrent counting operations. Supports integer and long types, allowing multiple users to increment or decrement a value simultaneously without conflicts. A **dedup** variant uses HyperLogLog to count unique actors (e.g., unique visitors). |
 
 ### Real-time Collaboration
 

--- a/docs/internals/crdt-concepts.mdx
+++ b/docs/internals/crdt-concepts.mdx
@@ -216,6 +216,7 @@ Yorkie handles concurrent edits differently depending on the data type:
 | **[Text](/docs/sdks/js-sdk#custom-crdt-types)** | Character-level merge (via RGATreeSplit) | Two users type at the same position; both characters appear based on their TimeTickets |
 | **[Tree](/docs/sdks/js-sdk#custom-crdt-types)** | Node-level merge (via [CRDTTree](#the-tree-crdt)) | Two users add child nodes to the same parent; both nodes appear in deterministic order |
 | **[Counter](/docs/sdks/js-sdk#custom-crdt-types)** | Additive merge | Two users increment by 1; the counter increases by 2 |
+| **Dedup Counter** | HLL max-merge | Two users record the same visitor; the counter stays at 1 (unique count) |
 
 This means your application does not need to implement any conflict resolution logic. As long as you use Yorkie's data types through `document.update()`, all conflicts are resolved automatically.
 

--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -623,6 +623,29 @@ doc.update((root) => {
 });
 ```
 
+**Dedup Counter**
+
+A Counter variant that uses a HyperLogLog sketch to deduplicate increments by actor ID.
+Useful for measuring unique visitors (UV) or other cardinality metrics where the same
+actor should only be counted once. Provides approximate counts with ~2% error rate.
+
+```javascript
+// Create a dedup counter (uses IntDedupType instead of IntType)
+doc.update((root) => {
+  root.uv = new yorkie.Counter(yorkie.IntDedupType, 0);
+});
+
+// Each unique actor is counted once; duplicates are ignored
+doc.update((root) => {
+  root.uv.increase(1, { actor: userId }); // UV: counted if new userId
+});
+```
+
+<Alert type="info">
+  Dedup counters do not support undo/redo because the internal HyperLogLog sketch is append-only.
+  The `increase` value must always be `1`.
+</Alert>
+
 #### TypeScript Support
 
 For stricter type checking, you can use [type variables](https://www.typescriptlang.org/docs/handbook/2/generics.html) in TypeScript when creating a Document.

--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -625,25 +625,22 @@ doc.update((root) => {
 
 **Dedup Counter**
 
-A Counter variant that uses a HyperLogLog sketch to deduplicate increments by actor ID.
-Useful for measuring unique visitors (UV) or other cardinality metrics where the same
-actor should only be counted once. Provides approximate counts with ~2% error rate.
+A Counter variant that uses a HyperLogLog sketch to count unique actors.
+Useful for measuring unique visitors (UV) where the same user should only be
+counted once. Provides approximate counts with ~2% error rate.
 
 ```javascript
-// Create a dedup counter (uses IntDedupType instead of IntType)
 doc.update((root) => {
-  root.uv = new yorkie.Counter(yorkie.IntDedupType, 0);
-});
+  // Create a dedup counter
+  root.uv = new yorkie.DedupCounter();
 
-// Each unique actor is counted once; duplicates are ignored
-doc.update((root) => {
-  root.uv.increase(1, { actor: userId }); // UV: counted if new userId
+  // Each unique actor is counted once; duplicates are ignored
+  root.uv.add(userId);
 });
 ```
 
 <Alert type="info">
-  Dedup counters do not support undo/redo because the internal HyperLogLog sketch is append-only.
-  The `increase` value must always be `1`.
+  Dedup counters do not support `increase()` or undo/redo. Use `add(actor)` to record unique actors.
 </Alert>
 
 #### TypeScript Support


### PR DESCRIPTION
## Summary

- Add Dedup Counter section to JS SDK docs (`docs/sdks/js-sdk.mdx`) with usage example and constraints
- Update Glossary with HyperLogLog dedup variant description
- Add HLL max-merge row to CRDT conflict resolution table in crdt-concepts

## Context

Companion to:
- yorkie-team/yorkie#1733 (Go server)
- yorkie-team/yorkie-js-sdk#1215 (JS SDK)

## Test plan

- [x] `npm run lint` passes (only pre-existing Mermaid warning)
- [ ] Visual review on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Counter glossary to describe a dedup variant using HyperLogLog for unique-actor counts.
  * Added Dedup Counter entry to CRDT concepts with an HLL max-merge conflict strategy and a unique-count example.
  * Added Dedup Counter docs to the JavaScript SDK with usage examples for recording actors; notes that increment-style operations and undo/redo are not supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->