### PR TITLE
Update JS SDK Counter docs for simplified interface

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -29,7 +29,7 @@ These terms are used in the Yorkie project and community. Understanding them wil
 | [YSON](/docs/internals/yson) | Yorkie JSON (YSON) is a JSON-like format for representing Yorkie documents, including custom CRDT types such as `Text`, `Tree`, `Counter`, along with specialized types like `Int`, `Long`, `Date`, and `BinData`. Used for document snapshots and serialization. |
 | [Text](/docs/sdks/js-sdk#custom-crdt-types) | A list-based CRDT type for collaborative rich text editing. Supports styling attributes and cursor sharing via presence. Used for integrations like [Quill](/examples/quill) and [CodeMirror](/examples/codemirror). |
 | [Tree](/docs/sdks/js-sdk#custom-crdt-types) | A tree-based CRDT type for structured rich text editing. Represents content as a hierarchical tree of nodes, similar to a DOM structure. |
-| [Counter](/docs/sdks/js-sdk#custom-crdt-types) | A CRDT type for concurrent counting operations. Supports integer and long types, allowing multiple users to increment or decrement a value simultaneously without conflicts. |
+| [Counter](/docs/sdks/js-sdk#custom-crdt-types) | A CRDT type for concurrent counting operations. Supports integer and long (bigint) types, allowing multiple users to increment or decrement a value simultaneously without conflicts. DedupCounter variant counts unique actors using HyperLogLog for UV measurement. |
 
 ### Real-time Collaboration
 

--- a/docs/internals/crdt-concepts.mdx
+++ b/docs/internals/crdt-concepts.mdx
@@ -216,6 +216,7 @@ Yorkie handles concurrent edits differently depending on the data type:
 | **[Text](/docs/sdks/js-sdk#custom-crdt-types)** | Character-level merge (via RGATreeSplit) | Two users type at the same position; both characters appear based on their TimeTickets |
 | **[Tree](/docs/sdks/js-sdk#custom-crdt-types)** | Node-level merge (via [CRDTTree](#the-tree-crdt)) | Two users add child nodes to the same parent; both nodes appear in deterministic order |
 | **[Counter](/docs/sdks/js-sdk#custom-crdt-types)** | Additive merge | Two users increment by 1; the counter increases by 2 |
+| **Dedup Counter** | HLL max-merge | Two users record the same visitor; the counter stays at 1 (unique count) |
 
 This means your application does not need to implement any conflict resolution logic. As long as you use Yorkie's data types through `document.update()`, all conflicts are resolved automatically.
 

--- a/docs/sample.mdx
+++ b/docs/sample.mdx
@@ -129,10 +129,10 @@ doc.update((root) => {
 
 // Counter supports numeric types that change with addition and subtraction.
 doc.update((root) => {
-  root.counter = new yorkie.Counter(yorkie.IntType, 1); // {"counter":1}
-  root.counter.increase(2);                             // {"counter":3}
-  root.counter.increase(3);                             // {"counter":6}
-  root.counter.increase(-4);                            // {"counter":2}
+  root.counter = new yorkie.Counter(1); // {"counter":1}
+  root.counter.increase(2);             // {"counter":3}
+  root.counter.increase(3);             // {"counter":6}
+  root.counter.increase(-4);            // {"counter":2}
 });`} 
     language="javascript" 
     withLineNumbers 

--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -108,7 +108,7 @@ Set initial values for the document root when attaching:
 await client.attach(doc, {
   initialRoot: {
     list: [1, 2, 3],
-    counter: new yorkie.Counter(yorkie.IntType, 0),
+    counter: new yorkie.Counter(0),
   },
 });
 ```
@@ -128,7 +128,7 @@ await client.attach(doc, {
 await client.attach(doc, {
   initialRoot: {
     list: [1, 2, 3],    // this update will be discarded
-    counter: new yorkie.Counter(yorkie.IntType, 0), // this update will be applied
+    counter: new yorkie.Counter(0), // this update will be applied
   },
 });
 
@@ -158,7 +158,7 @@ doc.update((root) => {
     name: 'yorkie',
     age: 14,
   };
-  root.counter = new yorkie.Counter(yorkie.IntType, 0);
+  root.counter = new yorkie.Counter(0);
   root.counter.increase(1);
 }, message);
 ```
@@ -612,16 +612,40 @@ Examples:
 
 **Counter**
 
-Supports integer operations with concurrent modifications:
+Supports integer operations with concurrent modifications. The counter type is inferred from the value: `number` for 32-bit integer, `bigint` for 64-bit long.
 
 ```javascript
 doc.update((root) => {
-  root.counter = new yorkie.Counter(yorkie.IntType, 1); // {"counter":1}
-  root.counter.increase(2);                             // {"counter":3}
-  root.counter.increase(3);                             // {"counter":6}
-  root.counter.increase(-4);                            // {"counter":2}
+  root.counter = new yorkie.Counter(1); // {"counter":1}
+  root.counter.increase(2);             // {"counter":3}
+  root.counter.increase(3);             // {"counter":6}
+  root.counter.increase(-4);            // {"counter":2}
+
+  // For 64-bit long counters, use bigint:
+  root.bigCounter = new yorkie.Counter(0n);
+  root.bigCounter.increase(1n);
 });
 ```
+
+**DedupCounter**
+
+Counts unique actors using HyperLogLog, useful for UV (unique visitor) measurement. Use `add(actor)` to record a unique visitor. Provides approximate counts with ~2% error rate.
+
+```javascript
+doc.update((root) => {
+  root.visitors = new yorkie.DedupCounter();
+  root.visitors.add(userId);
+});
+
+// Duplicate actors are ignored
+doc.update((root) => {
+  root.visitors.add(userId); // same user, count stays the same
+});
+```
+
+<Alert status="info">
+DedupCounter is designed for daily UV tracking. Create a separate document per day (e.g., `analytics-pageId-20260414`) to reset counts naturally.
+</Alert>
 
 #### TypeScript Support
 
@@ -890,7 +914,7 @@ console.log(doc.getRoot().text.toString()); // "Hello"
 
 ```javascript
 doc.update((root) => {
-  root.counter = new yorkie.Counter(yorkie.IntType, 0);
+  root.counter = new yorkie.Counter(0);
   root.counter.increase(5);
 });
 


### PR DESCRIPTION
## Summary

- Update Counter examples: `new yorkie.Counter(yorkie.IntType, N)` → `new yorkie.Counter(N)`
- Add DedupCounter documentation with UV measurement examples
- Update glossary with DedupCounter description and bigint mention

## Related

- JS SDK PR: yorkie-team/yorkie-js-sdk#1216
- Go server PR: yorkie-team/yorkie#1738

## Test plan

- [x] `npm run lint` passes
- [ ] `npm run build` (full site build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Counter behavior: automatic type inference for 32-bit integers and 64-bit longs (bigint) based on initial values
  * Added DedupCounter documentation describing approximate unique-actor counting using HyperLogLog and guidance for daily UV tracking
  * Simplified and unified Counter initialization examples and example formatting across docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->