### PR TITLE
Update Istio installation from istioctl to Helm

### DIFF
--- a/docs/self-hosted-server/aws-eks.mdx
+++ b/docs/self-hosted-server/aws-eks.mdx
@@ -18,9 +18,8 @@ This tutorial assumes that you are familiar with Kubernetes and `kubectl`.
 
 For this tutorial, you will need:
 
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.2.40+.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.28+.
 - [Helm](https://helm.sh/docs/intro/install/) v3.0+.
-- [istioctl](https://istio.io/latest/docs/setup/getting-started/#download) v1.17+, installed on your machine.
 
 ### Setup AWS EKS cluster
 
@@ -46,38 +45,47 @@ CoreDNS is running at https://12341234123412341234.gr7.ap-northeast-2.eks.amazon
 To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'. 
 ```
 
-### Install Istio with istioctl
+### Install Istio via Helm
 
-After AWS EKS is configured, you need to install Istio for Yorkie cluster.
+After AWS EKS is configured, you need to install [Istio](https://istio.io/latest/docs/setup/install/helm/) for Yorkie cluster.
 Yorkie cluster uses Istio for L7 load balancing and traffic management.
 
-Install Istio with the following command:
+First, add the Istio Helm repository and create the required namespaces:
 
 ```bash
-$ istioctl install -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-operator.yaml)
+$ helm repo add istio https://istio-release.storage.googleapis.com/charts
+$ helm repo update
+$ kubectl create namespace istio-system
+$ kubectl create namespace yorkie
 ```
 
-This will install Istio with [Istio Operator](https://istio.io/latest/docs/setup/install/operator/) configuration file.
-You can find the configuration file [here](https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-operator.yaml).
-
-When installing Istio, you will see the following output:
+Then, install Istio components in order. The value files are provided in the
+[yorkie-cluster chart repository](https://github.com/yorkie-team/yorkie/tree/main/build/charts/yorkie-cluster/istio-values).
 
 ```bash
-This will install the Istio 1.17.1 default profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N)
+# 1. Install Istio base (CRDs)
+$ helm install istio-base istio/base -n istio-system \
+  -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-values/base.yaml)
+
+# 2. Install istiod (control plane)
+$ helm install istiod istio/istiod -n istio-system --wait \
+  -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-values/istiod.yaml)
+
+# 3. Install yorkie-gateway
+$ helm install yorkie-gateway istio/gateway -n yorkie --wait \
+  -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-values/gateway.yaml)
 ```
 
-Type `y` and press `Enter` to continue.
-
-After Istio is installed, you will see the following output:
+After Istio is installed, verify all components are running:
 
 ```bash
-✔ Istio core installed
-✔ Istiod installed
-✔ Ingress gateways installed
-✔ Installation complete                                                                                             
-Making this installation the default for injection and validation.
+$ kubectl get pods -n istio-system
+NAME                      READY   STATUS    RESTARTS   AGE
+istiod-6b7f5d7b5f-abc12   1/1     Running   0          30s
 
-Thank you for installing Istio 1.17.  Please take a few minutes to tell us about your install/upgrade experience!  https://forms.gle/hMHGiwZHPU7UQRWe9
+$ kubectl get pods -n yorkie
+NAME                               READY   STATUS    RESTARTS   AGE
+yorkie-gateway-7f8b9c6d4e-xyz34    1/1     Running   0          20s
 ```
 
 ### Add yorkie-team Helm chart in your local repository
@@ -246,17 +254,14 @@ $ helm uninstall yorkie-cluster --namespace yorkie
 release "yorkie-cluster" uninstalled
 ```
 
-Then Uninstall Istio with the following command:
+Then, uninstall Istio components in reverse order:
 
 ```bash
-$ istioctl uninstall --purge
-All Istio resources will be pruned from the cluster
-Proceed? (y/N) y
-...
-✔ Uninstall complete
-
-# (Optional) Remove istio-system namespace
+$ helm uninstall yorkie-gateway -n yorkie
+$ helm uninstall istiod -n istio-system
+$ helm uninstall istio-base -n istio-system
 $ kubectl delete namespace istio-system
+$ kubectl delete namespace yorkie
 ```
 
 (Optional) Then, delete EKS cluster via AWS Console or AWS CLI.

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -16,16 +16,15 @@ This tutorial assumes that you are familiar with Kubernetes and `kubectl`.
 
 For this tutorial, you will need:
 
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.2.40+.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) v1.28+.
 - [Helm](https://helm.sh/docs/intro/install/) v3.0+.
-- [istioctl](https://istio.io/latest/docs/setup/getting-started/#download) v1.17+.
 - [Minikube](https://minikube.sigs.k8s.io/docs/start/) v1.30+ installed on your machine.
 
 ### Setup minikube on your machine
 
 First, you need to setup minikube on your machine to use Kubernetes locally and deploy Yorkie cluster.
 
-Start Minikube with the following command. The yorkie-cluster Helm chart deploys a Percona MongoDB sharded cluster (config server, 2 shards, mongos), 3 Yorkie replicas, and an Istio gateway, so you need to allocate sufficient CPU and memory resources:
+Start Minikube with the following command. The yorkie-cluster Helm chart deploys a Percona MongoDB sharded cluster (config server, 2 shards, mongos) and 3 Yorkie replicas, so you need to allocate sufficient CPU and memory resources:
 
 ```bash
 $ minikube start --cpus=4 --memory=8192 --driver=docker
@@ -59,44 +58,47 @@ After ingress addons are enabled, you will see the following output:
 🌟  The 'ingress' addon is enabled
 ```
 
-### Install Istio with istioctl
+### Install Istio via Helm
 
-After Minikube is configured, you need to install Istio for Yorkie cluster.
+After Minikube is configured, you need to install [Istio](https://istio.io/latest/docs/setup/install/helm/) for Yorkie cluster.
 Yorkie cluster uses Istio for L7 load balancing and traffic management.
 
-First, create the `yorkie` namespace with the following command:
+First, add the Istio Helm repository and create the required namespaces:
 
 ```bash
+$ helm repo add istio https://istio-release.storage.googleapis.com/charts
+$ helm repo update
+$ kubectl create namespace istio-system
 $ kubectl create namespace yorkie
 ```
 
-Then, install Istio with the following command:
+Then, install Istio components in order. The value files are provided in the
+[yorkie-cluster chart repository](https://github.com/yorkie-team/yorkie/tree/main/build/charts/yorkie-cluster/istio-values).
 
 ```bash
-$ istioctl install -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-operator.yaml)
+# 1. Install Istio base (CRDs)
+$ helm install istio-base istio/base -n istio-system \
+  -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-values/base.yaml)
+
+# 2. Install istiod (control plane)
+$ helm install istiod istio/istiod -n istio-system --wait \
+  -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-values/istiod.yaml)
+
+# 3. Install yorkie-gateway
+$ helm install yorkie-gateway istio/gateway -n yorkie --wait \
+  -f <(curl -s https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-values/gateway.yaml)
 ```
 
-This will install Istio with [Istio Operator](https://istio.io/latest/docs/setup/install/operator/) configuration file.
-You can find the configuration file [here](https://raw.githubusercontent.com/yorkie-team/yorkie/main/build/charts/yorkie-cluster/istio-operator.yaml).
-
-When installing Istio, you will see the following output:
+After Istio is installed, verify all components are running:
 
 ```bash
-This will install the Istio 1.17.1 default profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N)
-```
+$ kubectl get pods -n istio-system
+NAME                      READY   STATUS    RESTARTS   AGE
+istiod-6b7f5d7b5f-abc12   1/1     Running   0          30s
 
-Type `y` and press `Enter` to continue.
-
-After Istio is installed, you will see the following output:
-
-```bash
-✔ Istio core installed
-✔ Istiod installed
-✔ Ingress gateways installed
-✔ Installation complete                                                                                             
-Making this installation the default for injection and validation.
-
-Thank you for installing Istio 1.17.  Please take a few minutes to tell us about your install/upgrade experience!  https://forms.gle/hMHGiwZHPU7UQRWe9
+$ kubectl get pods -n yorkie
+NAME                               READY   STATUS    RESTARTS   AGE
+yorkie-gateway-7f8b9c6d4e-xyz34    1/1     Running   0          20s
 ```
 
 ### Add yorkie-team Helm chart in your local repository
@@ -318,16 +320,12 @@ $ helm uninstall yorkie-cluster --namespace yorkie
 release "yorkie-cluster" uninstalled
 ```
 
-Then, uninstall Istio with the following command:
+Then, uninstall Istio components in reverse order:
 
 ```bash
-$ istioctl uninstall --purge
-All Istio resources will be pruned from the cluster
-Proceed? (y/N) y
-...
-✔ Uninstall complete
-
-# (Optional) Remove istio-system namespace
+$ helm uninstall yorkie-gateway -n yorkie
+$ helm uninstall istiod -n istio-system
+$ helm uninstall istio-base -n istio-system
 $ kubectl delete namespace istio-system
 ```
 


### PR DESCRIPTION
## Summary
- Update Istio installation method from `istioctl install` (IstioOperator) to Helm-based 3-step install in Minikube and AWS EKS guides
- Remove `istioctl` from prerequisites, fix `kubectl` version to v1.28+
- Replace `istioctl uninstall --purge` with `helm uninstall` in cleanup sections

The yorkie-cluster chart v0.7.4 deprecated IstioOperator in favor of Helm-based installation (#303), so the docs need to reflect the current method.

## Test plan
- [x] `npm run lint` passed
- [x] `npm run build` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes version requirement to v1.28+
  * Revised Istio installation approach to use Helm charts instead of the previous method
  * Updated installation verification and cleanup procedures for AWS EKS and Minikube deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->