### PR TITLE
Bump version to v0.7.5

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,10 @@
 # Common Environment Variables
-NEXT_PUBLIC_YORKIE_VERSION='0.7.4'
-NEXT_PUBLIC_YORKIE_JS_VERSION='0.7.4'
+NEXT_PUBLIC_YORKIE_VERSION='0.7.5'
+NEXT_PUBLIC_YORKIE_JS_VERSION='0.7.5'
 NEXT_PUBLIC_YORKIE_IOS_VERSION='0.6.35'
 NEXT_PUBLIC_YORKIE_ANDROID_VERSION='0.6.35'
 NEXT_PUBLIC_DASHBOARD_PATH='/dashboard'
-NEXT_PUBLIC_JS_SDK_URL='https://cdn.jsdelivr.net/npm/@yorkie-js/sdk@0.7.4/dist/yorkie-js-sdk.js'
+NEXT_PUBLIC_JS_SDK_URL='https://cdn.jsdelivr.net/npm/@yorkie-js/sdk@0.7.5/dist/yorkie-js-sdk.js'
 NEXT_PUBLIC_STATUS_URL='https://stats.uptimerobot.com/otOOggryMR'
 
 # Development Environment Variables


### PR DESCRIPTION
## Summary
- Bump `NEXT_PUBLIC_YORKIE_VERSION` to 0.7.5
- Bump `NEXT_PUBLIC_YORKIE_JS_VERSION` to 0.7.5
- Bump `NEXT_PUBLIC_JS_SDK_URL` to @yorkie-js/sdk@0.7.5

## Test plan
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)