### PR TITLE
Link CLAUDE.md and MAINTAINING.md from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,8 @@ When PR is merged into main, it is automatically distributed by GitHub Actions.
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details on submitting patches and the contribution workflow.
+
+## Documentation
+
+- [MAINTAINING.md](MAINTAINING.md) — Release and maintenance procedures
+- [CLAUDE.md](CLAUDE.md) — Agent instructions for AI-assisted development


### PR DESCRIPTION
## Summary

Add a Documentation section to \`README.md\` linking \`CLAUDE.md\` and \`MAINTAINING.md\` so they are reachable from the project's entry point.

Found via the link connectivity check script being added to second-brain ([yorkie-team/second-brain#34](https://github.com/yorkie-team/second-brain/pull/34)).

The repo also has stale references inside the gitignored \`temp/\` directory (created by \`npm run fetch:examples\` to clone yorkie-js-sdk locally). Those are local-only build artifacts and don't appear in the repo, so this PR does not touch them.

## Test plan

- [x] Verified the new links resolve to existing files
- [ ] Reviewer to spot-check the new Documentation section