### PR TITLE
Document SyncMode.Polling for Channel and Document

### DIFF
--- a/docs/internals/synchronization.mdx
+++ b/docs/internals/synchronization.mdx
@@ -57,13 +57,14 @@ This local-first approach means your application remains responsive even with ne
 
 ### Sync Modes
 
-Yorkie provides four synchronization modes that control how a document syncs with the server. You can change the mode at any time using `client.changeSyncMode()`.
+Yorkie provides five synchronization modes that control how a document or channel syncs with the server. You can change the mode at any time using `client.changeSyncMode()`.
 
 | Mode | Push | Pull | Watch Stream | Use Case |
 |------|------|------|-------------|----------|
 | **`Realtime`** | Automatic | Automatic | Active | Default mode for real-time collaboration |
-| **`RealtimePushOnly`** | Automatic | Disabled | Active | When you want to send changes but not receive others (e.g., a presenter mode) |
-| **`RealtimeSyncOff`** | Disabled | Disabled | Active | Temporarily pause sync while staying aware of connection status |
+| **`RealtimePushOnly`** | Automatic | Disabled | Active | When you want to send changes but not receive others (e.g., a presenter mode). Document only. |
+| **`RealtimeSyncOff`** | Disabled | Disabled | Active | Temporarily pause sync while staying aware of connection status. Document only. |
+| **`Polling`** | Periodic | Periodic | Disconnected | Stream-less periodic sync. For Documents, pulls remote changes at the polling interval — not suitable for collaborative editing. For Channels, refreshes `sessionCount` without a watch stream — useful for large viewer counts where broadcast is not needed. |
 | **`Manual`** | Manual only | Manual only | Disconnected | Full control over when sync happens; useful for batch operations |
 
 ```javascript
@@ -77,6 +78,9 @@ await client.changeSyncMode(doc, SyncMode.RealtimePushOnly);
 
 // Pause all sync
 await client.changeSyncMode(doc, SyncMode.RealtimeSyncOff);
+
+// Switch to polling mode (no watch stream; pulls at the polling interval).
+await client.changeSyncMode(doc, SyncMode.Polling);
 
 // Switch to manual mode
 await client.changeSyncMode(doc, SyncMode.Manual);

--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -91,7 +91,8 @@ Attaching subscribes the client to a document. If the document doesn't exist on 
 
 Attach options:
 - `initialPresence`: Sets the client's initial presence when attaching to the document. The presence is shared with other users participating in the document. It must be serializable to JSON.
-- `syncMode`(Optional): Specifies synchronization modes. The default value is `SyncMode.Realtime`, which automatically pushes and pulls changes. If you set it to `SyncMode.Manual`, you'll need to manually handle synchronization.
+- `syncMode`(Optional): Specifies synchronization modes. The default value is `SyncMode.Realtime`, which automatically pushes and pulls changes. See [Synchronization Modes](#synchronization-modes) for the full list, including `SyncMode.Polling` for stream-less periodic sync.
+- `documentPollInterval`(Optional): Polling interval in milliseconds. Used only when `syncMode` is `SyncMode.Polling`. Defaults to `3000`.
 
 ```javascript
 await client.attach(doc, {
@@ -334,15 +335,17 @@ const unsubscribe = doc.subscribe('others', (event) => {
 
 #### Synchronization Modes
 
-Change the synchronization mode using `client.changeSyncMode(doc, syncMode)`:
+Change the synchronization mode at any time using `client.changeSyncMode(resource, syncMode)`. The resource can be a Document or a [Channel](#channel).
 
 Available modes:
 
-- `SyncMode.Realtime`: Local changes are automatically pushed to the server, and remote changes are pulled from the server.
+- `SyncMode.Realtime`: Local changes are automatically pushed to the server, and remote changes are pulled from the server. Watch stream is open.
 
-- `SyncMode.RealtimePushOnly`: Only local changes are pushed, and remote changes are not pulled.
+- `SyncMode.RealtimePushOnly` (Document only): Only local changes are pushed, and remote changes are not pulled.
 
-- `SyncMode.RealtimeSyncOff`: Changes are not synchronized, but the watch stream remains active.
+- `SyncMode.RealtimeSyncOff` (Document only): Changes are not synchronized, but the watch stream remains active.
+
+- `SyncMode.Polling`: No watch stream is opened. The existing sync loop drives `PushPullChanges` (Document) or the heartbeat (Channel) at a fixed interval. For Documents, remote changes arrive on the next polling tick — not suitable for collaborative editing. For Channels, recommended when broadcast events are not needed and `sessionCount` (an approximate count) is acceptable; useful for handling very large viewer counts where the watch stream cost dominates.
 
 - `SyncMode.Manual`: Synchronization no longer occurs in real-time, and the watch stream is disconnected. Manual handling is required for synchronization.
 
@@ -355,6 +358,9 @@ await client.changeSyncMode(doc, SyncMode.RealtimePushOnly);
 
 // Synchronization turned off, but the watch stream remains active.
 await client.changeSyncMode(doc, SyncMode.RealtimeSyncOff);
+
+// Stream-less periodic sync. Pull at documentPollInterval (default 3000 ms).
+await client.changeSyncMode(doc, SyncMode.Polling);
 
 // Synchronization turned off, and the watch stream is disconnected.
 await client.changeSyncMode(doc, SyncMode.Manual);
@@ -1009,6 +1015,22 @@ await client.attach(channel);
 ```
 
 > The channel key is used to identify the Channel in Yorkie. Clients with the same channel key can communicate with each other through pub/sub messaging.
+
+Attach options:
+- `syncMode`(Optional): Channel sync mode. Defaults to `SyncMode.Realtime`. Use `SyncMode.Polling` for stream-less periodic sync (recommended for large channels where broadcast events are not needed). `SyncMode.Manual` disables automatic activity. `RealtimePushOnly` and `RealtimeSyncOff` are document-only and rejected for channels.
+- `channelHeartbeatInterval`(Optional): Heartbeat interval in milliseconds. Mode-specific defaults: `Polling` → `3000`, `Realtime` → `30000`. Must be a positive number.
+
+```javascript
+// Default: Realtime — opens a watch stream for broadcast events.
+await client.attach(new yorkie.Channel('room-123'));
+
+// Polling: stream-less periodic sessionCount refresh, useful for large
+// viewer counts where broadcast is not needed.
+await client.attach(new yorkie.Channel('viewer-room'), {
+  syncMode: SyncMode.Polling,
+  channelHeartbeatInterval: 3000,
+});
+```
 
 #### Hierarchical Channel Keys
 

--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -95,9 +95,16 @@ Attach options:
 - `documentPollInterval`(Optional): Polling interval in milliseconds. Used only when `syncMode` is `SyncMode.Polling`. Defaults to `3000`.
 
 ```javascript
+// Manual mode: the caller drives sync via client.sync(doc).
 await client.attach(doc, {
   initialPresence: { color: 'blue', cursor: { x: 0, y: 0 } },
   syncMode: SyncMode.Manual,
+});
+
+// Polling mode: stream-less periodic sync; pulls every 5 seconds.
+await client.attach(doc, {
+  syncMode: SyncMode.Polling,
+  documentPollInterval: 5000,
 });
 ```
 

--- a/docs/sdks/react.mdx
+++ b/docs/sdks/react.mdx
@@ -176,10 +176,21 @@ Enable the [Devtools](/docs/tools/devtools) extension for debugging document sta
 | Prop | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | channelKey | string | Yes | - | Unique channel key (supports [hierarchical keys](/docs/sdks/js-sdk#hierarchical-channel-keys)) |
-| isRealtime | boolean | No | true | Session tracking mode |
+| syncMode | `SyncMode` | No | `SyncMode.Realtime` | Sync mode for the channel. See [Synchronization Modes](/docs/sdks/js-sdk#synchronization-modes). Use `SyncMode.Polling` to track `sessionCount` without a watch stream. |
+| isRealtime | boolean | No | - | Boolean shortcut covering only Realtime/Manual. `true` → `SyncMode.Realtime`, `false` → `SyncMode.Manual`. Cannot express `SyncMode.Polling`; use `syncMode` for that. If both props are set, `syncMode` wins. |
 
-- `isRealtime={true}` (default): The session count updates automatically via a watch stream. Use this for live "users online" indicators.
-- `isRealtime={false}`: Manual mode — the watch stream is not established, so session count will not update automatically. If you need messaging (broadcast/subscribe) or manual sync, use the JS SDK channel directly and manage the lifecycle yourself. Receiving broadcast events requires a watch stream.
+- `syncMode={SyncMode.Realtime}` (default): The session count updates automatically via a watch stream. Required to receive broadcast events through the JS SDK Channel.
+- `syncMode={SyncMode.Polling}`: Stream-less mode. The session count refreshes at `channelHeartbeatInterval` (default 3 seconds). Recommended for large channels where broadcast is not needed (e.g., showing approximate viewer count on read-only pages).
+- `syncMode={SyncMode.Manual}`: No automatic activity. Equivalent to `isRealtime={false}` for backward compatibility. Use the JS SDK channel directly to drive sync.
+
+```tsx
+import { ChannelProvider, SyncMode } from '@yorkie-js/react';
+
+// Large viewer-count page using polling.
+<ChannelProvider channelKey="live-stream-42" syncMode={SyncMode.Polling}>
+  <ViewerCounter />
+</ChannelProvider>
+```
 
 > Channel broadcast/subscribe hooks are planned for a future release. In the meantime, use the [JS SDK Channel API](/docs/sdks/js-sdk#channel) directly for messaging (and remember to unsubscribe/detach on unmount to avoid leaks).
 


### PR DESCRIPTION
#### What this PR does / why we need it?

Documents the new \`SyncMode.Polling\` value shipped in [yorkie-js-sdk#1243](https://github.com/yorkie-team/yorkie-js-sdk/pull/1243) and follow-ups so docs reflect the published API surface.

- \`docs/sdks/js-sdk.mdx\`:
  - Add \`documentPollInterval\` to AttachOptions.
  - Extend Synchronization Modes with \`SyncMode.Polling\`, note that \`changeSyncMode\` now accepts a Channel as well as a Document.
  - Add Channel attach options (\`syncMode\`, \`channelHeartbeatInterval\`) with a Polling code example.
- \`docs/internals/synchronization.mdx\`: Add the Polling row to the Sync Modes table ("five" instead of "four") and a Polling case in the example.
- \`docs/sdks/react.mdx\`: Add the \`syncMode\` prop to the \`<ChannelProvider>\` props table alongside \`isRealtime\`, with a tsx example showing the large-viewer-count use case.

#### Any background context you want to provide?

The Polling mode is opt-in. It runs the existing sync loop without opening a watch stream, so:
- Documents in Polling mode pull at the configured interval (not suitable for collaborative editing).
- Channels in Polling mode refresh \`sessionCount\` via heartbeat without a watch stream — recommended for large viewer counts where broadcast events are not needed.

The React SDK will re-export \`SyncMode\` once [yorkie-js-sdk#1245](https://github.com/yorkie-team/yorkie-js-sdk/pull/1245) merges, so the React example imports \`SyncMode\` from \`@yorkie-js/react\` directly.

Android/iOS SDK pages are intentionally untouched: those SDKs do not yet support Polling.

#### What are the relevant tickets?

Documents [yorkie-js-sdk#1243](https://github.com/yorkie-team/yorkie-js-sdk/pull/1243) and [yorkie-js-sdk#1245](https://github.com/yorkie-team/yorkie-js-sdk/pull/1245).

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated synchronization documentation across JS SDK, React SDK, and internals guides to include all available sync modes with configuration examples.
  * Added Polling sync mode documentation with use-case guidance and parameters for periodic synchronization.
  * Enhanced explanations of synchronization options and their respective behaviors for different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->