### PR TITLE
Document wildcard syntax for Allowed Origins

### DIFF
--- a/docs/advanced/security.mdx
+++ b/docs/advanced/security.mdx
@@ -19,6 +19,17 @@ Each project in Yorkie can have its own allowed origins settings, which can be m
 
 <Image alt="setting allowed-origins" src="/assets/images/docs/allowed-origins-dashboard.png" width={1300} height={640} style={{ maxWidth: '1000px' }} />
 
+#### Pattern Syntax
+
+Each entry must be either `*` (allow any origin) or a full origin URL. The host portion may contain `*` as a wildcard:
+
+- `https://example.com` — exact origin only.
+- `https://*.example.com` — any single subdomain, such as `https://api.example.com`.
+- `https://*-m.example.com` — any subdomain ending in `-m`, such as `https://mini-m.example.com`.
+- `https://api-*.example.com` — any subdomain starting with `api-`.
+
+`*` matches any sequence of characters within a single DNS label only. `.` is a hard boundary, so `https://*.example.com` does **not** match `https://a.b.example.com`. The scheme and port must match exactly.
+
 ### Auth Webhook
 
 The Auth Webhook provides fine-grained access control by validating client requests through an external authentication server. This allows you to enforce custom authorization logic, ensuring only authorized users can access and modify Yorkie documents.


### PR DESCRIPTION
#### What this PR does / why we need it?

Adds a "Pattern Syntax" subsection to the Allowed Origins page so project owners can see that wildcards are supported and understand the matching rules. Before this, the docs only described entering exact domains, and users entering values like `https://*.example.com` had no signal that the wildcard was being interpreted.

#### Any background context you want to provide?

Pairs with yorkie-team/yorkie#1810, which makes `*` actually work inside host labels (it was previously stored as a literal string and silently never matched). The docs change describes the syntax that ships with that server change:

- `*` allows any origin (existing behavior).
- `https://*.example.com` matches any single subdomain.
- `https://*-m.example.com` / `https://api-*.example.com` match within-label wildcards.
- `.` is a hard boundary, so `https://*.example.com` does not match `https://a.b.example.com`.
- Scheme and port still must match exactly.

#### What are the relevant tickets?

Fixes #

Related: yorkie-team/yorkie#1810

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded security documentation with new guidance on wildcard pattern syntax for allowed origins, covering supported entry formats, valid wildcard placement rules, and matching behavior with DNS labels and scheme/port exactness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-team.github.io/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->