### PR TITLE
Document per-project ChannelSessionTTL setting

### DIFF
--- a/docs/advanced/resources.mdx
+++ b/docs/advanced/resources.mdx
@@ -114,6 +114,7 @@ Control how documents and clients are managed over time.
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `client-deactivate-threshold` | 24h | Time after which inactive clients are deactivated |
+| `channel-session-ttl` | 15s | Time a presence channel session is retained after its last refresh (1s..5m) |
 | `remove-on-detach` | false | Automatically remove documents when all clients detach |
 | `auto-revision-enabled` | true | Automatically create revisions during snapshot creation |
 
@@ -125,6 +126,20 @@ Clients that haven't communicated with the server for longer than this threshold
 yorkie project update [project-name] \
   --client-deactivate-threshold 48h
 ```
+
+#### ChannelSessionTTL
+
+The duration a presence channel session is retained on the server after its last refresh. Raising the value keeps users counted in the live presence count longer after they leave, which is useful for small rooms where the count would otherwise feel volatile. The value must be between `1s` and `5m`; the default is `15s` (matching the server-wide default).
+
+```bash
+yorkie project update [project-name] \
+  --channel-session-ttl 1m
+```
+
+**When to use:**
+- **Small-room presence**: Raise to `30s`–`1m` so brief visits keep the live count from collapsing
+- **Tight real-time feedback**: Keep at the `15s` default when accurate "live now" counts matter more than smoothing
+- **High-churn rooms**: Combine with the SDK's heartbeat interval (Channel sessions are refreshed every `TTL/3`); lowering the TTL increases refresh traffic linearly
 
 #### RemoveOnDetach
 
@@ -160,6 +175,7 @@ When enabled, revisions are automatically created during snapshot creation. Revi
 | SnapshotThreshold | `--snapshot-threshold` | 500 | int |
 | SnapshotInterval | `--snapshot-interval` | 500 | int |
 | ClientDeactivateThreshold | `--client-deactivate-threshold` | 24h | duration |
+| ChannelSessionTTL | `--channel-session-ttl` | 15s | duration (1s..5m) |
 | RemoveOnDetach | `--remove-on-detach` | false | bool |
 | AutoRevisionEnabled | Admin API only | true | bool |
 

--- a/docs/tools/cli.mdx
+++ b/docs/tools/cli.mdx
@@ -275,6 +275,7 @@ Flags:
       --auth-webhook-method-add stringArray    authorization-webhook methods to add ('ALL' for all methods)
       --auth-webhook-method-rm stringArray     authorization-webhook methods to remove ('ALL' for all methods)
       --auth-webhook-url string                authorization-webhook update url
+      --channel-session-ttl string             channel session TTL (must be between 1s and 5m)
       --client-deactivate-threshold string     client deactivate threshold for housekeeping
       --event-webhook-events-add stringArray   event-webhook events to add ('ALL' for all events)
       --event-webhook-events-rm stringArray    event-webhook events to remove ('ALL' for all events)
@@ -474,3 +475,15 @@ $ yorkie project update test-project --client-deactivate-threshold 1h30m20s
 ```
 
 Setting the client deactivation threshold to `1h30m20s` deactivates clients that have been inactive for 1 hour, 30 minutes, and 20 seconds but remained activated. This helps document GC by not counting the deactivated client's document sequence.
+
+#### Channel Session TTL
+
+Channel Session TTL is a per-project duration that controls how long a presence channel session is retained on the server after its last refresh. Raising the value keeps users counted in the live presence count longer after they leave — useful for small rooms where the live count would otherwise feel volatile. The value must be between `1s` and `5m`; the default is `15s`.
+
+Set the channel session TTL of the project with the `--channel-session-ttl` flag.
+
+```bash
+$ yorkie project update test-project --channel-session-ttl 1m
+```
+
+Values outside the `[1s, 5m]` range are rejected by the admin API. Lowering the TTL increases refresh traffic from active clients linearly (the SDK heartbeat targets `TTL/3`).


### PR DESCRIPTION
## Summary

- Documents the per-project \`ChannelSessionTTL\` setting in the Resources guide (\`docs/advanced/resources.mdx\`) and CLI reference (\`docs/tools/cli.mdx\`). The setting (range \`1s..5m\`, default \`15s\`) controls how long a presence channel session is retained on the server after its last refresh.
- Adds the setting to the Lifecycle Settings table, a new \`#### ChannelSessionTTL\` subsection with usage guidance (when to raise, when to keep default, refresh-traffic tradeoff), and the Configuration Reference table.
- Adds the \`--channel-session-ttl\` flag to the \`yorkie project update\` CLI examples and a parallel "Channel Session TTL" subsection.

Companion to:
- [yorkie-team/yorkie#1827](https://github.com/yorkie-team/yorkie-team/yorkie/pull/1827) (merged) — backend + CLI
- [yorkie-team/dashboard#298](https://github.com/yorkie-team/dashboard/pull/298) — Settings UI

## Test plan

- [x] \`npm run lint\` — 0 errors (1 pre-existing warning in unrelated \`Mermaid.tsx\`)
- [x] \`npm run build\` — Next.js build + sitemap generation succeed
- [x] Manual: \`npm run dev\` and visit \`/docs/advanced/resources\` to confirm rendering of the new subsection, table rows, and CLI example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the `channel-session-ttl` configuration option, which controls how long presence channel sessions are retained (valid range: 1s–5m, default: 15s).
  * Updated CLI tools documentation with the new `--channel-session-ttl` flag for configuring presence channel session behavior in project settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-team.github.io/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->