### PR TITLE
Update internal docs for TreeList and fix design-doc links

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -56,7 +56,7 @@ These terms are used in the Yorkie project and community. Understanding them wil
 
 | Word | Description |
 | ---- | ----------- |
-| [CRDT Element](/docs/internals/crdt-concepts#crdt-elements-and-nodes) | A data structure representing a CRDT element, analogous to an Element in the DOM. For more information, see [CRDT Concepts](/docs/internals/crdt-concepts) and the [Data Structures design doc](https://github.com/yorkie-team/yorkie/blob/main/design/data-structure.md). |
+| [CRDT Element](/docs/internals/crdt-concepts#crdt-elements-and-nodes) | A data structure representing a CRDT element, analogous to an Element in the DOM. For more information, see [CRDT Concepts](/docs/internals/crdt-concepts) and the [Data Structures design doc](https://github.com/yorkie-team/yorkie/blob/main/docs/design/data-structure.md). |
 | [CRDT Node](/docs/internals/crdt-concepts#crdt-elements-and-nodes) | A single node within a CRDT element. |
 | [TimeTicket](/docs/internals/crdt-concepts#timetickets) | A globally unique identifier for every CRDT node, composed of a Lamport timestamp, an ActorID (the creating client), and a delimiter. TimeTickets provide both uniqueness and a total ordering for conflict resolution. |
 | [Version Vector](/docs/internals/crdt-concepts#version-vectors) | A Lamport Synced Version Vector -- a hybrid logical clock that combines Lamport timestamps with version vectors. Used to track causal relationships between clients for [Garbage Collection](/docs/internals/crdt-concepts#garbage-collection). |

--- a/docs/internals/cluster-mode.mdx
+++ b/docs/internals/cluster-mode.mdx
@@ -121,7 +121,7 @@ Leader election is enforced at the database level:
 
 All nodes send periodic **heartbeats** to the database to indicate they are alive. The cluster uses a **liveness window** (default: 10 seconds) to detect inactive nodes.
 
-For the full design, see the [Membership Management design document](https://github.com/yorkie-team/yorkie/blob/main/design/membership.md).
+For the full design, see the [Membership Management design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/membership.md).
 
 ### MongoDB Sharding
 
@@ -138,7 +138,7 @@ Hashed sharding on `doc_id` for document-wide collections provides:
 - **Improved write performance**: Writes are distributed across all shards.
 - **Better scalability**: New shards immediately participate in handling traffic.
 
-For the full sharding strategy, see the [MongoDB Sharding design document](https://github.com/yorkie-team/yorkie/blob/main/design/mongodb-sharding.md).
+For the full sharding strategy, see the [MongoDB Sharding design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/mongodb-sharding.md).
 
 ### Watch Stream in Cluster Mode
 
@@ -162,7 +162,7 @@ To maximize concurrency on popular documents, Yorkie uses **fine-grained locking
 
 Locks are always acquired in order (`doc` → `doc.pull` → `doc.attachment` → `doc.push`) to prevent deadlocks. This allows concurrent reads during compaction and independent push/pull operations.
 
-For the full design, see the [Fine-Grained Document Locking design document](https://github.com/yorkie-team/yorkie/blob/main/design/fine-grained-document-locking.md).
+For the full design, see the [Fine-Grained Document Locking design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/fine-grained-document-locking.md).
 
 ### Production Deployment Considerations
 
@@ -171,7 +171,7 @@ When deploying a Yorkie cluster in production:
 - **Database redundancy**: Use a MongoDB replica set (recommended: 3 members per shard) for data safety.
 - **Multiple routers**: Deploy at least 2 Istio Ingress Gateways for high availability.
 - **Monitoring**: Track leader election failures, heartbeat timestamps, lock wait times, and broadcast success rates.
-- **Housekeeping tuning**: Adjust the `Interval`, `CandidatesLimit`, and `CompactionMinChanges` settings based on your workload. See the [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/design/housekeeping.md) for configuration examples.
+- **Housekeeping tuning**: Adjust the `Interval`, `CandidatesLimit`, and `CompactionMinChanges` settings based on your workload. See the [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/housekeeping.md) for configuration examples.
 
 ### Further Reading
 
@@ -179,8 +179,8 @@ When deploying a Yorkie cluster in production:
 - [Self-Hosted Server on Minikube](/docs/self-hosted-server/minikube) -- Local Kubernetes deployment guide
 - [Self-Hosted Server on AWS EKS](/docs/self-hosted-server/aws-eks) -- AWS deployment guide
 - [Cluster Addons](/docs/self-hosted-server/cluster-addons) -- Additional components for cluster deployments
-- [Sharded Cluster Mode design document](https://github.com/yorkie-team/yorkie/blob/main/design/sharded-cluster-mode.md) -- Full consistent hashing design
-- [Membership Management design document](https://github.com/yorkie-team/yorkie/blob/main/design/membership.md) -- Leader election and node lifecycle
-- [MongoDB Sharding design document](https://github.com/yorkie-team/yorkie/blob/main/design/mongodb-sharding.md) -- Database sharding strategy
-- [Fine-Grained Document Locking design document](https://github.com/yorkie-team/yorkie/blob/main/design/fine-grained-document-locking.md) -- Concurrency optimization
+- [Sharded Cluster Mode design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/sharded-cluster-mode.md) -- Full consistent hashing design
+- [Membership Management design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/membership.md) -- Leader election and node lifecycle
+- [MongoDB Sharding design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/mongodb-sharding.md) -- Database sharding strategy
+- [Fine-Grained Document Locking design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/fine-grained-document-locking.md) -- Concurrency optimization
 - [Glossary](/docs/glossary) -- Definitions of all key terms

--- a/docs/internals/crdt-concepts.mdx
+++ b/docs/internals/crdt-concepts.mdx
@@ -70,11 +70,12 @@ General-purpose data structures used by the CRDT layer:
 
 | Type | Description |
 |------|-------------|
-| **[SplayTree](https://en.wikipedia.org/wiki/Splay_tree)** | A self-adjusting binary search tree. Moves frequently accessed nodes to the root, which is effective for text editing where users access nearby positions. Used as an index tree to provide fast positional access. |
+| **[SplayTree](https://en.wikipedia.org/wiki/Splay_tree)** | A self-adjusting binary search tree. Moves frequently accessed nodes to the root, which is effective for text editing where users access nearby positions. Used as the index tree in **RGATreeSplit** for fast positional access in text. |
+| **TreeList** | An order-statistic tree on a [Left-leaning Red-Black Tree](https://en.wikipedia.org/wiki/Left-leaning_red%E2%80%93black_tree), with O(log N) worst-case index-based access. Used as the index tree of **RGATreeList**. |
 | **[LLRBTree](https://en.wikipedia.org/wiki/Left-leaning_red%E2%80%93black_tree)** | A left-leaning red-black tree. Simpler than a standard red-black tree, used for ordered key lookups. |
 | **IndexTree** | A tree structure representing the document model of text-based editors. |
 
-For the full dependency graph and technical details, see the [Data Structures design document](https://github.com/yorkie-team/yorkie/blob/main/design/data-structure.md).
+For the full dependency graph and technical details, see the [Data Structures design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/data-structure.md).
 
 ### Logical Clocks and TimeTickets
 
@@ -108,7 +109,7 @@ To solve this, Yorkie uses a **Lamport Synced Version Vector** -- a hybrid of La
 
 The server uses the **minimum Version Vector** (`minVersionVector`) across all active clients to determine when tombstoned nodes can be safely garbage collected.
 
-For the full technical design, see the [Version Vector design document](https://github.com/yorkie-team/yorkie/blob/main/design/version-vector.md).
+For the full technical design, see the [Version Vector design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/version-vector.md).
 
 ### CRDT Elements and Nodes
 
@@ -159,7 +160,7 @@ The Tree CRDT guarantees eventual consistency across 27 concurrent editing cases
 - **`insertAfter` only**: Like the RGA, all insertions reference a left sibling node, ensuring deterministic ordering.
 - **`maxCreatedAtMapByActor`**: A map that tracks the latest creation time per actor within an editing range, enabling the system to distinguish concurrent from causally related operations and prevent unintended deletions.
 
-For the full technical design, see the [Tree design document](https://github.com/yorkie-team/yorkie/blob/main/design/tree.md).
+For the full technical design, see the [Tree design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/tree.md).
 
 ### Tombstones
 
@@ -201,9 +202,9 @@ sequenceDiagram
 
 #### Text-Specific Garbage Collection
 
-For [Text](/docs/sdks/js-sdk#custom-crdt-types) types, GC works at the text node level within the RGATreeSplit structure. Tombstoned text nodes are cached during editing and removed from the linked list during garbage collection, making them eligible for runtime memory reclamation. For details, see the [GC for Text Type design document](https://github.com/yorkie-team/yorkie/blob/main/design/gc-for-text-type.md).
+For [Text](/docs/sdks/js-sdk#custom-crdt-types) types, GC works at the text node level within the RGATreeSplit structure. Tombstoned text nodes are cached during editing and removed from the linked list during garbage collection, making them eligible for runtime memory reclamation. For details, see the [GC for Text Type design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/gc-for-text-type.md).
 
-For the full GC design, see the [Garbage Collection design document](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md).
+For the full GC design, see the [Garbage Collection design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md).
 
 ### Conflict Resolution in Practice
 
@@ -222,10 +223,10 @@ This means your application does not need to implement any conflict resolution l
 
 ### Further Reading
 
-- [Data Structures design document](https://github.com/yorkie-team/yorkie/blob/main/design/data-structure.md) -- Technical details on how Yorkie represents data internally
-- [Garbage Collection design document](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md) -- Deep dive into the GC mechanism
-- [Version Vector design document](https://github.com/yorkie-team/yorkie/blob/main/design/version-vector.md) -- Hybrid logical clock system
-- [Tree design document](https://github.com/yorkie-team/yorkie/blob/main/design/tree.md) -- Tree CRDT for block-based editors
+- [Data Structures design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/data-structure.md) -- Technical details on how Yorkie represents data internally
+- [Garbage Collection design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md) -- Deep dive into the GC mechanism
+- [Version Vector design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/version-vector.md) -- Hybrid logical clock system
+- [Tree design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/tree.md) -- Tree CRDT for block-based editors
 - [Document Lifecycle](/docs/internals/document-lifecycle) -- States and transitions of documents and clients
 - [JS SDK: Custom CRDT Types](/docs/sdks/js-sdk#custom-crdt-types) -- How to use Text, Tree, and Counter in your application
 - [YSON](/docs/internals/yson) -- The serialization format for Yorkie documents

--- a/docs/internals/document-lifecycle.mdx
+++ b/docs/internals/document-lifecycle.mdx
@@ -165,9 +165,9 @@ The `PushPull` synchronization operation is **only available in the Attached sta
 
 ### Further Reading
 
-- [Document-Client Lifecycle design document](https://github.com/yorkie-team/yorkie/blob/main/design/document-client-lifecycle.md) -- Full state machine with detailed transitions
-- [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/design/document-editing.md) -- How local and remote editing works internally
-- [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/design/housekeeping.md) -- Client deactivation and document compaction
+- [Document-Client Lifecycle design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/document-client-lifecycle.md) -- Full state machine with detailed transitions
+- [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/document-editing.md) -- How local and remote editing works internally
+- [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/housekeeping.md) -- Client deactivation and document compaction
 - [Synchronization](/docs/internals/synchronization) -- PushPullChanges, checkpoints, and sync modes
 - [CRDT Concepts: Garbage Collection](/docs/internals/crdt-concepts#garbage-collection) -- How GC relates to client lifecycle
 - [JS SDK: Document](/docs/sdks/js-sdk#document) -- SDK reference for document operations

--- a/docs/internals/housekeeping.mdx
+++ b/docs/internals/housekeeping.mdx
@@ -162,10 +162,10 @@ These logs show the number of candidates processed, the actions taken, and the d
 
 ### Further Reading
 
-- [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/design/housekeeping.md) -- Full technical design
+- [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/housekeeping.md) -- Full technical design
 - [CRDT Concepts: Garbage Collection](/docs/internals/crdt-concepts#garbage-collection) -- How GC uses version vectors to reclaim tombstones
 - [Synchronization: Document Compaction](/docs/internals/synchronization#document-compaction) -- How compaction fits into the sync lifecycle
-- [Garbage Collection design document](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md) -- Deep dive into the GC mechanism
+- [Garbage Collection design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md) -- Deep dive into the GC mechanism
 - [Projects](/docs/advanced/projects) -- Per-project configuration including housekeeping thresholds
 - [CLI: Updating the Project](/docs/tools/cli#updating-the-project) -- How to configure client deactivation threshold
 - [Cluster Mode](/docs/internals/cluster-mode) -- Leader election and distributed coordination

--- a/docs/internals/synchronization.mdx
+++ b/docs/internals/synchronization.mdx
@@ -53,7 +53,7 @@ When another client's changes arrive:
 2. The Changes are applied to the local **Root** using CRDT merge rules.
 3. Subscribed event handlers (via `document.subscribe()`) are called with the change events.
 
-This local-first approach means your application remains responsive even with network latency. For the full technical details, see the [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/design/document-editing.md).
+This local-first approach means your application remains responsive even with network latency. For the full technical details, see the [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/document-editing.md).
 
 ### Sync Modes
 
@@ -230,7 +230,7 @@ doc.subscribe('connection', (event) => {
 
 When the watch stream disconnects, local changes are buffered and pushed once the connection is restored. This is how Yorkie supports offline editing.
 
-For the full PubSub design, see the [PubSub design document](https://github.com/yorkie-team/yorkie/blob/main/design/pub-sub.md).
+For the full PubSub design, see the [PubSub design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/pub-sub.md).
 
 ### Document Compaction
 
@@ -259,9 +259,9 @@ Here's the complete lifecycle of a document from attachment to detachment. For t
 ### Further Reading
 
 - [Document Lifecycle](/docs/internals/document-lifecycle) -- State transitions of documents and clients
-- [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/design/document-editing.md) -- Root/Clone/LocalChanges architecture
-- [PubSub design document](https://github.com/yorkie-team/yorkie/blob/main/design/pub-sub.md) -- Watch stream implementation
-- [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/design/housekeeping.md) -- Background compaction and cleanup
+- [Document Editing design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/document-editing.md) -- Root/Clone/LocalChanges architecture
+- [PubSub design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/pub-sub.md) -- Watch stream implementation
+- [Housekeeping design document](https://github.com/yorkie-team/yorkie/blob/main/docs/design/housekeeping.md) -- Background compaction and cleanup
 - [JS SDK: Synchronization Modes](/docs/sdks/js-sdk#synchronization-modes) -- SDK reference for sync mode APIs
 - [JS SDK: Subscribing to Changes](/docs/sdks/js-sdk#subscribing-to-changes) -- How to react to local, remote, and snapshot events
 - [CRDT Concepts](/docs/internals/crdt-concepts) -- How CRDTs ensure conflict-free merging

--- a/docs/sdks/ios-sdk.mdx
+++ b/docs/sdks/ios-sdk.mdx
@@ -69,7 +69,7 @@ When the client is no longer needed, you can deactivate it to release resources 
 try await client.deactivate()
 ```
 
-This will detach all documents attached to the client for efficient [garbage collection](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md).
+This will detach all documents attached to the client for efficient [garbage collection](https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md).
 
 ### Document
 
@@ -485,7 +485,7 @@ try await client.sync(doc) // Trigger synchronization manually using the sync fu
 
 #### Detaching the Document
 
-If the document is no longer needed, detach it to improve the efficiency of garbage collection removing [CRDT tombstones](https://crdt.tech/glossary). For more information about GC, see [Garbage Collection](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md).
+If the document is no longer needed, detach it to improve the efficiency of garbage collection removing [CRDT tombstones](https://crdt.tech/glossary). For more information about GC, see [Garbage Collection](https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md).
 
 ```swift
 try await client.detach(doc)

--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -69,7 +69,7 @@ When the client is no longer needed, you can deactivate it to release resources 
 await client.deactivate();
 ```
 
-This will detach all documents attached to the client for efficient [garbage collection](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md).
+This will detach all documents attached to the client for efficient [garbage collection](https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md).
 
 ### Document
 

--- a/docs/self-hosted-server/aws-eks.mdx
+++ b/docs/self-hosted-server/aws-eks.mdx
@@ -279,4 +279,4 @@ $ aws eks delete-cluster --name {YOUR_CLUSTER_NAME}
 You can also install Yorkie Cluster addons to monitor metrics and perform GitOps on Yorkie cluster.
 
 - For more information, see [Self-Hosting Guide: Cluster Addons Installation](/docs/self-hosted-server/cluster-addons).
-- For more information about Yorkie cluster design, follow: [Yorkie Cluster Design](https://github.com/yorkie-team/yorkie/blob/main/design/sharded-cluster-mode.md)
+- For more information about Yorkie cluster design, follow: [Yorkie Cluster Design](https://github.com/yorkie-team/yorkie/blob/main/docs/design/sharded-cluster-mode.md)

--- a/docs/self-hosted-server/cluster-addons.mdx
+++ b/docs/self-hosted-server/cluster-addons.mdx
@@ -531,4 +531,4 @@ $ kubectl delete namespace analytics
 
 ### Next Steps
 
-For more information about Yorkie cluster design, follow: [Yorkie Cluster Design](https://github.com/yorkie-team/yorkie/blob/main/design/sharded-cluster-mode.md)
+For more information about Yorkie cluster design, follow: [Yorkie Cluster Design](https://github.com/yorkie-team/yorkie/blob/main/docs/design/sharded-cluster-mode.md)

--- a/docs/self-hosted-server/minikube.mdx
+++ b/docs/self-hosted-server/minikube.mdx
@@ -353,4 +353,4 @@ $ minikube delete
 You can also install Yorkie cluster addons to monitor metrics and perform GitOps on Yorkie cluster.
 
 - For more information, see [Self-Hosting Guide: Cluster Addons Installation](/docs/self-hosted-server/cluster-addons).
-- For more information about Yorkie cluster design, follow: [Yorkie Cluster Design](https://github.com/yorkie-team/yorkie/blob/main/design/sharded-cluster-mode.md)
+- For more information about Yorkie cluster design, follow: [Yorkie Cluster Design](https://github.com/yorkie-team/yorkie/blob/main/docs/design/sharded-cluster-mode.md)

--- a/docs/tools/cli.mdx
+++ b/docs/tools/cli.mdx
@@ -464,7 +464,7 @@ $ yorkie document remove test-project test-document-1
 
 #### Client Deactivate Threshold
 
-Client Deactivate Threshold is a time duration that determines when clients are deactivated for documents in projects. Deactivating the client and detaching it from documents improves the efficiency of garbage collection removing [CRDT tombstones](https://crdt.tech/glossary). For more information about GC, see [Garbage Collection](https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md).
+Client Deactivate Threshold is a time duration that determines when clients are deactivated for documents in projects. Deactivating the client and detaching it from documents improves the efficiency of garbage collection removing [CRDT tombstones](https://crdt.tech/glossary). For more information about GC, see [Garbage Collection](https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md).
 
 Set the client deactivate threshold of the project with the `--client-deactivate-threshold` flag.
 

--- a/pages/products.tsx
+++ b/pages/products.tsx
@@ -245,7 +245,7 @@ const Products: NextPage = () => {
                 <p className="product_card_desc">
                   Yorkie uses{' '}
                   <a
-                    href="https://github.com/yorkie-team/yorkie/blob/main/design/garbage-collection.md"
+                    href="https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md"
                     className="link"
                   >
                     Garbage Collection


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Yorkie moved design docs from design/ to docs/design/, breaking 35 links across 13 docs and pages/products.tsx. Repoint all of them to the new location.

Also update CRDT Concepts to reflect yorkie-team/yorkie#1685:
- Add TreeList row to the Common Layer table (LLRB-based order- statistic tree, O(log N) worst-case index-based access).
- Narrow SplayTree's description to RGATreeSplit (text), since RGATreeList no longer uses it.
- Rewrite the RGA section's "Positional access" bullet around the TreeList-based index.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [X] Added relevant tests or not required
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal design documentation reference links across multiple guides to point to the correct paths, including glossary, cluster concepts, CRDT documentation, SDK guides, and server deployment resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-team.github.io/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->