### PR TITLE
Document disableGC attach option and PeekChannel

### DIFF
--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -93,6 +93,7 @@ Attach options:
 - `initialPresence`: Sets the client's initial presence when attaching to the document. The presence is shared with other users participating in the document. It must be serializable to JSON.
 - `syncMode`(Optional): Specifies synchronization modes. The default value is `SyncMode.Realtime`, which automatically pushes and pulls changes. See [Synchronization Modes](#synchronization-modes) for the full list, including `SyncMode.Polling` for stream-less periodic sync.
 - `documentPollInterval`(Optional): Polling interval in milliseconds. Used only when `syncMode` is `SyncMode.Polling`. Defaults to `3000`.
+- `disableGC`(Optional): Opts the attachment out of server-side `VersionVector` tracking, reducing per-`PushPull` payload for high-fan-out workloads. Defaults to `false`. See [Disabling GC](#disabling-gc) before enabling.
 
 ```javascript
 // Manual mode: the caller drives sync via client.sync(doc).
@@ -151,6 +152,18 @@ We support element types for Primitives, and [Custom CRDT types](/docs/sdks/js-s
 
 <Alert status="warning">
 Elements added by `initialRoot` are applied locally after push-pull during `attach`, not sent to the server immediately.
+</Alert>
+
+#### Disabling GC
+
+For documents whose workload never produces tombstones — typically `Counter`-only or primitive-value replacement documents — you can attach with `disableGC: true`. The server then skips `minVersionVector` tracking for this attachment and omits the response `VersionVector`, which removes a per-`PushPull` cost that scales with the number of active clients.
+
+```javascript
+await client.attach(doc, { disableGC: true });
+```
+
+<Alert status="warning">
+`disableGC` only controls the wire contract with the server. Misuse on documents that use `Tree`, `Text`, or `Array` deletions leads to undefined garbage-collection behavior on this client — tombstones may accumulate without being purged. Only enable it for workloads you are certain never produce tombstones.
 </Alert>
 
 #### Editing the Document
@@ -1155,6 +1168,25 @@ The session count is automatically updated when clients connect or disconnect fr
 <Alert status="warning">
 Sessions are connection-based and managed for scalability. In abnormal cases (such as app crashes or network partitions), a client might not detach cleanly, so the server may keep the session counted until it is considered stale and cleaned up. This means the displayed count can be approximate and may lag briefly. Avoid using session counts as a source of truth for critical business logic such as billing, authorization, or settlements.
 </Alert>
+
+#### Peeking Session Count
+
+Use `client.peekChannel(channelKey)` to read a channel's current `sessionCount` **without joining** the channel. No `Session` is created on the server, no broadcast events are received, and there is no pub/sub fan-out cost for the caller.
+
+```javascript
+const count = await client.peekChannel('post-writers');
+```
+
+This is the recommended path for **display-only** counters shown across many surrounding pages — for example, a "N people writing" badge attached to every item in a feed. Each viewer would otherwise occupy a `Session` slot and contribute heartbeat/pubsub load to a channel they are not actually participating in.
+
+| | `attach()` | `peekChannel()` |
+|---|---|---|
+| Server state per caller | `Session` + indexes | none |
+| Network per caller | heartbeat | one request per call |
+| Receives broadcasts | yes | no |
+| Use case | participate in the channel | display the count only |
+
+Pair `peekChannel` with your own polling cadence to refresh the displayed count. The client must be activated before calling it.
 
 #### Detaching a Channel
 

--- a/docs/sdks/react.mdx
+++ b/docs/sdks/react.mdx
@@ -103,6 +103,7 @@ Set `userID` in the `metadata` prop to measure Monthly Active Users. The `userID
 | initialRoot | `Record<string, any>` | No | {} | Initial values for the document root |
 | initialPresence | `Record<string, any>` | No | {} | Initial presence data for the current client |
 | enableDevtools | boolean | No | false | Enable [Devtools](/docs/tools/devtools) integration |
+| disableGC | boolean | No | undefined | Opts out of server-side `VersionVector` tracking for this attachment. Only safe for documents that never produce tombstones (e.g. Counter-only). See [JS SDK: Disabling GC](/docs/sdks/js-sdk#disabling-gc) for the caveat. |
 
 **Basic usage:**
 
@@ -162,6 +163,16 @@ Enable the [Devtools](/docs/tools/devtools) extension for debugging document sta
 ```tsx
 <DocumentProvider docKey="my-doc" enableDevtools={true}>
   <MyApp />
+</DocumentProvider>
+```
+
+**disableGC:**
+
+Opt out of server-side `VersionVector` tracking for this attachment to reduce per-`PushPull` cost on high-fan-out workloads. Only safe for documents that never produce tombstones — typically Counter-only or primitive-value replacement. See [JS SDK: Disabling GC](/docs/sdks/js-sdk#disabling-gc) for the full caveat.
+
+```tsx
+<DocumentProvider docKey="counter" disableGC>
+  <Counter />
 </DocumentProvider>
 ```
 
@@ -578,6 +589,43 @@ function OnlineBadge() {
 }
 ```
 
+##### usePeekChannel
+
+`usePeekChannel` polls a channel's session count **without attaching** to it — no `Session` is created on the server and no broadcasts are received. It does **not** require a `ChannelProvider`; only an enclosing `YorkieProvider` is needed. See [JS SDK: Peeking Session Count](/docs/sdks/js-sdk#peeking-session-count) for when to choose this over `useChannel`.
+
+**Signature:**
+
+```tsx
+const { sessionCount, loading, error } = usePeekChannel(
+  channelKey: string,
+  options?: {
+    pollInterval?: number; // default 3000 (ms)
+    enabled?: boolean;     // default true; set false to pause polling
+  },
+);
+```
+
+**Example:**
+
+```tsx
+import { usePeekChannel } from '@yorkie-js/react';
+
+function WritersBadge() {
+  const { sessionCount } = usePeekChannel('post-writers', {
+    pollInterval: 2000,
+  });
+  return <span>{sessionCount} writing</span>;
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| sessionCount | number | Current session count for the channel |
+| loading | boolean | `true` while the initial peek is in flight |
+| error | Error \| undefined | Error from the most recent peek call, if any |
+
+> Use this for display-only counters shown across many pages (e.g. a "N people writing" badge on every feed item). For interactive channel membership — broadcasts or contributing to the count — use [`ChannelProvider`](#channelprovider) with `useChannel` instead.
+
 #### Standalone Hook
 
 ##### useYorkieDoc
@@ -594,6 +642,7 @@ const { root, update, loading, error } = useYorkieDoc<DocType>(
     rpcAddr?: string;
     initialRoot?: Record<string, any>;
     enableDevtools?: boolean;
+    disableGC?: boolean;
   }
 );
 ```
@@ -602,6 +651,15 @@ const { root, update, loading, error } = useYorkieDoc<DocType>(
 - Isolated features that don't share a client with the rest of the app
 - Micro frontends or embeddable widgets
 - Quick prototyping without setting up providers
+
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| rpcAddr | string | - | Yorkie server address |
+| initialRoot | `Record<string, any>` | {} | Initial values for the document root |
+| enableDevtools | boolean | false | Enable [Devtools](/docs/tools/devtools) integration |
+| disableGC | boolean | undefined | Opts out of server-side `VersionVector` tracking. Only safe for documents that never produce tombstones. See [JS SDK: Disabling GC](/docs/sdks/js-sdk#disabling-gc). |
 
 **Example:**
 

--- a/docs/sdks/react.mdx
+++ b/docs/sdks/react.mdx
@@ -545,7 +545,7 @@ For more details on revision concepts, snapshots, and best practices, see the [R
 
 #### Channel Hooks
 
-The following hooks must be used inside a `ChannelProvider`.
+`useChannel` and `useChannelSessionCount` must be used inside a `ChannelProvider`. `usePeekChannel` is the exception — it only needs an enclosing `YorkieProvider`.
 
 ##### useChannel
 


### PR DESCRIPTION
## Summary

Covers two SDK additions shipped since v0.7.9 that were missing from the JS/React SDK guides.

- **`disableGC` attach option** (SDK [#1265](https://github.com/yorkie-team/yorkie-js-sdk/pull/1265) in v0.7.10, React [#1268](https://github.com/yorkie-team/yorkie-js-sdk/pull/1268) in v0.7.11)
  - `docs/sdks/js-sdk.mdx`: added to the Attaching the Document option list and a new **Disabling GC** subsection that documents the tombstone caveat.
  - `docs/sdks/react.mdx`: exposed on `DocumentProvider` (props table + usage block) and `useYorkieDoc` (options table).
- **PeekChannel** (SDK [#1256](https://github.com/yorkie-team/yorkie-js-sdk/pull/1256) in v0.7.9)
  - `docs/sdks/js-sdk.mdx`: new **Peeking Session Count** subsection in the Channel section, with an attach-vs-peek comparison table.
  - `docs/sdks/react.mdx`: new `usePeekChannel` hook entry under Channel Hooks (does not require `ChannelProvider`).

## Test plan

- [x] `npm run lint` — clean (pre-existing Mermaid.tsx warning only)
- [x] `npm run build` — passes; sitemap generated
- [x] Spot-check rendered pages for the new anchors `#disabling-gc` and `#peeking-session-count`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `disableGC` attachment option in JS and React SDKs to opt out of server-side GC tracking.
  * Added peek-only channel APIs (JS peek method and React `usePeekChannel` hook) to read channel session counts without joining.

* **Documentation**
  * Updated SDK docs with examples, usage caveats, and guidance comparing peek vs attach and GC implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->