### PR TITLE
Document disablePresence attach option

### DIFF
--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -94,6 +94,7 @@ Attach options:
 - `syncMode`(Optional): Specifies synchronization modes. The default value is `SyncMode.Realtime`, which automatically pushes and pulls changes. See [Synchronization Modes](#synchronization-modes) for the full list, including `SyncMode.Polling` for stream-less periodic sync.
 - `documentPollInterval`(Optional): Polling interval in milliseconds. Used only when `syncMode` is `SyncMode.Polling`. Defaults to `3000`.
 - `disableGC`(Optional): Opts the attachment out of server-side `VersionVector` tracking, reducing per-`PushPull` payload for high-fan-out workloads. Defaults to `false`. See [Disabling GC](#disabling-gc) before enabling.
+- `disablePresence`(Optional): Opts the attachment out of presence map propagation for documents that don't need presence (e.g. `Counter`-only, form, or read-mostly documents). Defaults to `false`. See [Disabling Presence](#disabling-presence) before enabling.
 
 ```javascript
 // Manual mode: the caller drives sync via client.sync(doc).
@@ -164,6 +165,18 @@ await client.attach(doc, { disableGC: true });
 
 <Alert status="warning">
 `disableGC` only controls the wire contract with the server. Misuse on documents that use `Tree`, `Text`, or `Array` deletions leads to undefined garbage-collection behavior on this client — tombstones may accumulate without being purged. Only enable it for workloads you are certain never produce tombstones.
+</Alert>
+
+#### Disabling Presence
+
+For documents that don't need presence — typically `Counter`-only, form, or read-mostly documents — you can attach with `disablePresence: true`. The server then strips the presence map from snapshots and changes, and no presence updates are propagated for the attachment.
+
+```javascript
+await client.attach(doc, { disablePresence: true });
+```
+
+<Alert status="info">
+`disablePresence` is fixated on the first attach and is immutable afterwards. If a later attach specifies a different value, the server returns the persisted value rather than the requested one. To change it, create a new document key, or have an administrator update the value directly in storage.
 </Alert>
 
 #### Editing the Document

--- a/docs/sdks/react.mdx
+++ b/docs/sdks/react.mdx
@@ -104,6 +104,7 @@ Set `userID` in the `metadata` prop to measure Monthly Active Users. The `userID
 | initialPresence | `Record<string, any>` | No | {} | Initial presence data for the current client |
 | enableDevtools | boolean | No | false | Enable [Devtools](/docs/tools/devtools) integration |
 | disableGC | boolean | No | undefined | Opts out of server-side `VersionVector` tracking for this attachment. Only safe for documents that never produce tombstones (e.g. Counter-only). See [JS SDK: Disabling GC](/docs/sdks/js-sdk#disabling-gc) for the caveat. |
+| disablePresence | boolean | No | undefined | Opts out of presence map propagation for this attachment. Useful for Counter-only, form, or read-mostly documents. See [JS SDK: Disabling Presence](/docs/sdks/js-sdk#disabling-presence). |
 
 **Basic usage:**
 
@@ -172,6 +173,16 @@ Opt out of server-side `VersionVector` tracking for this attachment to reduce pe
 
 ```tsx
 <DocumentProvider docKey="counter" disableGC>
+  <Counter />
+</DocumentProvider>
+```
+
+**disablePresence:**
+
+Opt out of presence map propagation for this attachment. Useful for `Counter`-only, form, or read-mostly documents that don't need presence. The value is fixated on the first attach — see [JS SDK: Disabling Presence](/docs/sdks/js-sdk#disabling-presence) for details.
+
+```tsx
+<DocumentProvider docKey="counter" disablePresence>
   <Counter />
 </DocumentProvider>
 ```
@@ -643,6 +654,7 @@ const { root, update, loading, error } = useYorkieDoc<DocType>(
     initialRoot?: Record<string, any>;
     enableDevtools?: boolean;
     disableGC?: boolean;
+    disablePresence?: boolean;
   }
 );
 ```
@@ -660,6 +672,7 @@ const { root, update, loading, error } = useYorkieDoc<DocType>(
 | initialRoot | `Record<string, any>` | {} | Initial values for the document root |
 | enableDevtools | boolean | false | Enable [Devtools](/docs/tools/devtools) integration |
 | disableGC | boolean | undefined | Opts out of server-side `VersionVector` tracking. Only safe for documents that never produce tombstones. See [JS SDK: Disabling GC](/docs/sdks/js-sdk#disabling-gc). |
+| disablePresence | boolean | undefined | Opts out of presence map propagation. Useful for Counter-only, form, or read-mostly documents. See [JS SDK: Disabling Presence](/docs/sdks/js-sdk#disabling-presence). |
 
 **Example:**
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Document the new Document-scope `disablePresence` attach option in the JS SDK and React SDK guides.

- `docs/sdks/js-sdk.mdx`: add to the AttachOptions list and a new `#### Disabling Presence` section.
- `docs/sdks/react.mdx`: add to `DocumentProvider` props, `useYorkieDoc` options (table + type signature), and a
`**disablePresence:**` example block.

#### Any background context you want to provide?

`disablePresence: true` lets clients attach to documents whose workload doesn't need presence (Counter-only, form,
read-mostly). The server strips the presence map from snapshots and changes for these attachments. The value is
fixated on first attach via `$setOnInsert`, so later attach calls with a different value receive the persisted value
 back — recovery is to use a new docKey or update storage directly.

#### What are the relevant tickets?

- yorkie-team/yorkie#1841
- yorkie-team/yorkie-js-sdk#1285

Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented new `disablePresence` option for JavaScript SDK document attachment, allowing users to opt out of presence propagation.
  * Added `disablePresence` support to React SDK's `DocumentProvider` component and `useYorkieDoc` hook with configuration guidance.
  * Included behavior explanation: presence is stripped from snapshots and updates are not propagated when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->