### PR TITLE
Document JS/React SDK options added through v0.7.12

### DIFF
--- a/docs/sdks/js-sdk.mdx
+++ b/docs/sdks/js-sdk.mdx
@@ -71,6 +71,30 @@ await client.deactivate();
 
 This will detach all documents attached to the client for efficient [garbage collection](https://github.com/yorkie-team/yorkie/blob/main/docs/design/garbage-collection.md).
 
+`deactivate()` accepts an optional `DeactivateOptions`:
+
+- `keepalive`(Optional): Defaults to `false`. When `true`, the deactivation request is sent immediately using `fetch` with the `keepalive` option, ensuring it completes even while the page is unloading. Use this inside `beforeunload`/`unload` handlers.
+- `synchronous`(Optional): Defaults to `false`. When `true`, the server waits for all pending operations to complete before deactivating.
+
+```javascript
+// Ensure deactivation completes during page unload.
+window.addEventListener('beforeunload', () => {
+  void client.deactivate({ keepalive: true });
+});
+```
+
+By default the client registers its own `beforeunload` listener during `activate()` that deactivates the client when the page is unloaded. This is controlled by the `deactivateOnUnload` client option (default `true`):
+
+```javascript
+const client = new yorkie.Client({
+  rpcAddr: '{{API_ADDR}}',
+  apiKey: 'xxxxxxxxxxxxxxxxxxxx',
+  deactivateOnUnload: false,
+});
+```
+
+Set `deactivateOnUnload: false` for apps that don't need GC or presence cleanup on unload — for example, non-collaborative apps or documents attached with `disableGC`. In those cases the unload-time deactivate is pure overhead, and its `fetch({ keepalive: true })` request can reject mid-flight during hard navigation. Opting out is safe: the server reaps the stale client after its [Client Deactivate Threshold](/docs/tools/cli#client-deactivate-threshold).
+
 ### Document
 
 `Document` is the primary data type in Yorkie, providing a JSON-like updating experience for representing your application's model. Documents can be updated without being attached to the client, and changes automatically propagate to other clients when attached or when the network is restored.
@@ -84,6 +108,18 @@ const doc = new yorkie.Document('doc-1');
 ```
 
 > Document keys can contain `a-z`, `A-Z`, `0-9`, `-`, `.`, `_`, `~` and must be less than 120 characters.
+
+The constructor also accepts an optional second argument, `DocumentOptions`:
+
+- `disableGC`(Optional): Disables garbage collection for this document. Defaults to `false`. See [Disabling GC](#disabling-gc).
+- `disablePresence`(Optional): Declares that this document does not use presence. Defaults to `false`. See [Disabling Presence](#disabling-presence).
+- `enableDevtools`(Optional): Enables the [Devtools extension](/docs/tools/devtools) for this document. Defaults to `false`.
+
+```javascript
+const doc = new yorkie.Document('doc-1', { disablePresence: true });
+```
+
+The `disableGC` and `disablePresence` values seed the corresponding attach-time options of the same name. When the matching attach option is omitted, the document's seeded value is used.
 
 #### Attaching the Document
 
@@ -1051,7 +1087,7 @@ await client.attach(channel);
 
 Attach options:
 - `syncMode`(Optional): Channel sync mode. Defaults to `SyncMode.Realtime`. Use `SyncMode.Polling` for stream-less periodic sync (recommended for large channels where broadcast events are not needed). `SyncMode.Manual` disables automatic activity. `RealtimePushOnly` and `RealtimeSyncOff` are document-only and rejected for channels.
-- `channelHeartbeatInterval`(Optional): Heartbeat interval in milliseconds. Mode-specific defaults: `Polling` → `3000`, `Realtime` → `30000`. Must be a positive number.
+- `channelHeartbeatInterval`(Optional): Heartbeat interval in milliseconds for this attachment. Must be a positive number. If unset, the client-level `channelHeartbeatInterval` (`ClientOptions.channelHeartbeatInterval`, default `5000`) applies to both `Realtime` and `Polling` modes — there is no mode-specific default.
 
 ```javascript
 // Default: Realtime — opens a watch stream for broadcast events.
@@ -1061,7 +1097,7 @@ await client.attach(new yorkie.Channel('room-123'));
 // viewer counts where broadcast is not needed.
 await client.attach(new yorkie.Channel('viewer-room'), {
   syncMode: SyncMode.Polling,
-  channelHeartbeatInterval: 3000,
+  channelHeartbeatInterval: 3000, // override the 5000 ms client-level default
 });
 ```
 

--- a/docs/sdks/react.mdx
+++ b/docs/sdks/react.mdx
@@ -38,6 +38,10 @@ npm install @yorkie-js/react
 | rpcAddr | string | No | `https://api.yorkie.dev` | Yorkie API server address |
 | authTokenInjector | `(reason?: string) => Promise<string>` | No | undefined | Async function that returns an auth token for [Auth Webhook](/docs/advanced/security#auth-webhook) verification |
 | metadata | `Record<string, string>` | No | {} | Client metadata (e.g., `{ userID: '...' }` for MAU measurement) |
+| activate | boolean | No | true | Whether to call `client.activate()` on mount and `client.deactivate()` on unmount. Set to `false` for channel-only apps — the SDK lazy-attaches the client on the first heartbeat, so the explicit activate round trips become unnecessary. Document use cases (`useDocument`, `useYorkieDoc`) still require activation, so leave this `true` if any descendant attaches a document. |
+| deactivateOnUnload | boolean | No | true | Whether to deactivate the client on page unload. Set to `false` to skip the unmount-time `client.deactivate({ keepalive: true })` for apps that don't need GC or presence cleanup on unload (e.g. non-collaborative or `disableGC` documents). See [JS SDK: deactivateOnUnload](/docs/sdks/js-sdk#deactivate-the-client). |
+
+`YorkieProviderProps` extends [`ClientOptions`](/docs/sdks/js-sdk), so any client option (e.g. `deactivateOnUnload`) can be passed directly as a prop in addition to the provider-level `activate` flag.
 
 **Basic usage:**
 
@@ -103,6 +107,8 @@ Set `userID` in the `metadata` prop to measure Monthly Active Users. The `userID
 | initialRoot | `Record<string, any>` | No | {} | Initial values for the document root |
 | initialPresence | `Record<string, any>` | No | {} | Initial presence data for the current client |
 | enableDevtools | boolean | No | false | Enable [Devtools](/docs/tools/devtools) integration |
+| syncMode | `SyncMode` | No | `SyncMode.Realtime` | Synchronization mode for the document. See [Synchronization Modes](/docs/sdks/js-sdk#synchronization-modes). |
+| documentPollInterval | number | No | 3000 | Poll interval in ms. Only used when `syncMode` is `SyncMode.Polling`. Applied at attach time. |
 | disableGC | boolean | No | undefined | Opts out of server-side `VersionVector` tracking for this attachment. Only safe for documents that never produce tombstones (e.g. Counter-only). See [JS SDK: Disabling GC](/docs/sdks/js-sdk#disabling-gc) for the caveat. |
 | disablePresence | boolean | No | undefined | Opts out of presence map propagation for this attachment. Useful for Counter-only, form, or read-mostly documents. See [JS SDK: Disabling Presence](/docs/sdks/js-sdk#disabling-presence). |
 
@@ -200,9 +206,10 @@ Opt out of presence map propagation for this attachment. Useful for `Counter`-on
 | channelKey | string | Yes | - | Unique channel key (supports [hierarchical keys](/docs/sdks/js-sdk#hierarchical-channel-keys)) |
 | syncMode | `SyncMode` | No | `SyncMode.Realtime` | Sync mode for the channel. See [Synchronization Modes](/docs/sdks/js-sdk#synchronization-modes). Use `SyncMode.Polling` to track `sessionCount` without a watch stream. |
 | isRealtime | boolean | No | - | Boolean shortcut covering only Realtime/Manual. `true` → `SyncMode.Realtime`, `false` → `SyncMode.Manual`. Cannot express `SyncMode.Polling`; use `syncMode` for that. If both props are set, `syncMode` wins. |
+| channelHeartbeatInterval | number | No | 5000 | Overrides the heartbeat interval (ms), applied at attach time. The default is 5000 ms for both Realtime and Polling modes (co-tuned to the server's `ChannelSessionTTL`). |
 
 - `syncMode={SyncMode.Realtime}` (default): The session count updates automatically via a watch stream. Required to receive broadcast events through the JS SDK Channel.
-- `syncMode={SyncMode.Polling}`: Stream-less mode. The session count refreshes at `channelHeartbeatInterval` (default 3 seconds). Recommended for large channels where broadcast is not needed (e.g., showing approximate viewer count on read-only pages).
+- `syncMode={SyncMode.Polling}`: Stream-less mode. The session count refreshes at `channelHeartbeatInterval` (default 5000 ms). Recommended for large channels where broadcast is not needed (e.g., showing approximate viewer count on read-only pages).
 - `syncMode={SyncMode.Manual}`: No automatic activity. Equivalent to `isRealtime={false}` for backward compatibility. Use the JS SDK channel directly to drive sync.
 
 ```tsx
@@ -234,6 +241,35 @@ function App() {
 
 ### Hooks
 
+#### Client Hook
+
+##### useYorkie
+
+`useYorkie` returns the Yorkie `Client` provided by `YorkieProvider`, along with its loading and error state. It must be used under a `YorkieProvider`. Use this when you need direct access to the client for low-level [JS SDK](/docs/sdks/js-sdk) operations not covered by the higher-level hooks.
+
+```tsx
+const { client, loading, error } = useYorkie();
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| client | `Client \| undefined` | The Yorkie client. `undefined` until activation completes. |
+| loading | boolean | `true` while the client is being activated |
+| error | Error \| undefined | Error object if activation failed |
+
+```tsx
+import { useYorkie } from '@yorkie-js/react';
+
+function ClientStatus() {
+  const { client, loading, error } = useYorkie();
+
+  if (loading) return <p>Connecting...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return <p>Client ready: {client?.getID()}</p>;
+}
+```
+
 #### Document Hooks
 
 The following hooks must be used inside a `DocumentProvider`.
@@ -246,6 +282,7 @@ The following hooks must be used inside a `DocumentProvider`.
 
 ```tsx
 const {
+  doc,
   root,
   presences,
   connection,
@@ -259,6 +296,7 @@ const {
 
 | Property | Type | Description |
 |----------|------|-------------|
+| doc | `Document<DocType, PresenceType> \| undefined` | The underlying document instance. `undefined` until the document is attached. |
 | root | DocType | The document's root object |
 | presences | `Array<{ clientID: string; presence: PresenceType }>` | All participating clients and their presence data |
 | connection | `StreamConnectionStatus` | Watch stream connection status (`StreamConnectionStatus.Connected` or `StreamConnectionStatus.Disconnected`). Import from `@yorkie-js/sdk`. |
@@ -554,6 +592,36 @@ function RevisionPanel() {
 
 For more details on revision concepts, snapshots, and best practices, see the [Revisions](/docs/advanced/revisions) guide.
 
+##### useRemoveDocument
+
+`useRemoveDocument` returns a zero-argument function that removes the current document from the server via `client.remove()`. This is distinct from detach: it removes the document for **every** client, not just the current one, after which the key can be reattached as a fresh document. This hook must be used within a `DocumentProvider`.
+
+**TypeScript signature:**
+
+```tsx
+const removeDocument: () => Promise<void> = useRemoveDocument<DocType, PresenceType>();
+```
+
+The returned function rejects if the document is not yet attached, and propagates any removal error to the caller.
+
+```tsx
+import { useRemoveDocument } from '@yorkie-js/react';
+
+function DeleteButton() {
+  const removeDocument = useRemoveDocument();
+
+  const handleDelete = async () => {
+    try {
+      await removeDocument();
+    } catch (e) {
+      console.error('Failed to remove document:', e);
+    }
+  };
+
+  return <button onClick={handleDelete}>Delete document</button>;
+}
+```
+
 #### Channel Hooks
 
 `useChannel` and `useChannelSessionCount` must be used inside a `ChannelProvider`. `usePeekChannel` is the exception — it only needs an enclosing `YorkieProvider`.
@@ -580,6 +648,7 @@ function RoomStatus() {
 | sessionCount | number | Number of clients currently connected to the channel |
 | loading | boolean | `true` while the channel is being attached |
 | error | Error \| undefined | Error object if attachment failed |
+| detach | `() => Promise<void>` | Idempotent function that permanently stops the channel from inside the tree (e.g. on `error`) without unmounting the surrounding `ChannelProvider`. Safe to call more than once. |
 
 > `sessionCount` is session-based, not unique-user-based. A single user with multiple tabs open will be counted as multiple sessions.
 
@@ -602,16 +671,16 @@ function OnlineBadge() {
 
 ##### usePeekChannel
 
-`usePeekChannel` polls a channel's session count **without attaching** to it — no `Session` is created on the server and no broadcasts are received. It does **not** require a `ChannelProvider`; only an enclosing `YorkieProvider` is needed. See [JS SDK: Peeking Session Count](/docs/sdks/js-sdk#peeking-session-count) for when to choose this over `useChannel`.
+`usePeekChannel` reads a channel's session count **without attaching** to it — no `Session` is created on the server and no broadcasts are received. By default it fetches once on mount and does not poll; pass a positive `pollInterval` to opt into continuous polling. It does **not** require a `ChannelProvider`; only an enclosing `YorkieProvider` is needed. See [JS SDK: Peeking Session Count](/docs/sdks/js-sdk#peeking-session-count) for when to choose this over `useChannel`.
 
 **Signature:**
 
 ```tsx
-const { sessionCount, loading, error } = usePeekChannel(
+const { sessionCount, loading, error, refetch } = usePeekChannel(
   channelKey: string,
   options?: {
-    pollInterval?: number; // default 3000 (ms)
-    enabled?: boolean;     // default true; set false to pause polling
+    pollInterval?: number; // no default — unset fetches once on mount; set a positive ms value to poll
+    enabled?: boolean;     // default true; set false to pause fetching
   },
 );
 ```
@@ -632,8 +701,9 @@ function WritersBadge() {
 | Property | Type | Description |
 |----------|------|-------------|
 | sessionCount | number | Current session count for the channel |
-| loading | boolean | `true` while the initial peek is in flight |
+| loading | boolean | `true` before the first successful fetch (or while a `refetch()` is in flight) |
 | error | Error \| undefined | Error from the most recent peek call, if any |
+| refetch | `() => Promise<void>` | Issues a peek immediately, ignoring `pollInterval`. Useful on button clicks or after user actions that may have changed the count. |
 
 > Use this for display-only counters shown across many pages (e.g. a "N people writing" badge on every feed item). For interactive channel membership — broadcasts or contributing to the count — use [`ChannelProvider`](#channelprovider) with `useChannel` instead.
 
@@ -646,18 +716,22 @@ function WritersBadge() {
 **Signature:**
 
 ```tsx
-const { root, update, loading, error } = useYorkieDoc<DocType>(
+const { root, presences, connection, update, loading, error } = useYorkieDoc<DocType, PresenceType>(
   apiKey: string,
   docKey: string,
-  options?: {
-    rpcAddr?: string;
+  options?: Omit<ClientOptions, 'apiKey'> & {
     initialRoot?: Record<string, any>;
+    initialPresence?: Record<string, any>;
     enableDevtools?: boolean;
+    syncMode?: SyncMode;
+    documentPollInterval?: number;
     disableGC?: boolean;
     disablePresence?: boolean;
   }
 );
 ```
+
+In addition to the document-specific options below, `options` accepts any [`ClientOptions`](/docs/sdks/js-sdk) field except `apiKey` (which is passed as the first argument) — for example `rpcAddr`, `metadata`, or `authTokenInjector`.
 
 **When to use:**
 - Isolated features that don't share a client with the rest of the app
@@ -668,9 +742,12 @@ const { root, update, loading, error } = useYorkieDoc<DocType>(
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| rpcAddr | string | - | Yorkie server address |
+| rpcAddr | string | - | Yorkie server address (inherited from `ClientOptions`) |
 | initialRoot | `Record<string, any>` | {} | Initial values for the document root |
+| initialPresence | `Record<string, any>` | {} | Initial presence data for the current client |
 | enableDevtools | boolean | false | Enable [Devtools](/docs/tools/devtools) integration |
+| syncMode | `SyncMode` | `SyncMode.Realtime` | Synchronization mode for the document. See [Synchronization Modes](/docs/sdks/js-sdk#synchronization-modes). |
+| documentPollInterval | number | 3000 | Poll interval in ms. Only used when `syncMode` is `SyncMode.Polling`. |
 | disableGC | boolean | undefined | Opts out of server-side `VersionVector` tracking. Only safe for documents that never produce tombstones. See [JS SDK: Disabling GC](/docs/sdks/js-sdk#disabling-gc). |
 | disablePresence | boolean | undefined | Opts out of presence map propagation. Useful for Counter-only, form, or read-mostly documents. See [JS SDK: Disabling Presence](/docs/sdks/js-sdk#disabling-presence). |
 


### PR DESCRIPTION
## Summary

Syncs the JS and React SDK docs with the current SDK surface (`yorkie-js-sdk` v0.7.12). Audited the docs against the SDK source and filled in options/hooks added in the 0.7.x line, plus corrected a few stale signatures/defaults.

Scope intentionally limited to the **JS SDK** and **React SDK** pages. ProseMirror / schema-validation / devtools were checked too but are deferred for a separate review.

## JS SDK — `docs/sdks/js-sdk.mdx`
- Document `deactivateOnUnload` client option and `DeactivateOptions` (`keepalive`, `synchronous`)
- Document the optional `DocumentOptions` constructor argument (`disableGC`, `disablePresence`, `enableDevtools`)
- **Fix**: `channelHeartbeatInterval` default is the client-level `5000` ms for both Realtime and Polling — not the previously documented mode-specific `3000`/`30000`

## React SDK — `docs/sdks/react.mdx`
- Add `useYorkie` and `useRemoveDocument` hooks
- Add `activate` and `deactivateOnUnload` props to `YorkieProvider`; note `YorkieProviderProps` extends `ClientOptions`
- Add `syncMode`/`documentPollInterval` (`DocumentProvider`) and `channelHeartbeatInterval` (`ChannelProvider`) props
- Add `doc` to `useDocument`, `detach` to `useChannel`, `refetch` to `usePeekChannel`
- **Fix**: `usePeekChannel` `pollInterval` has no default (fetches once on mount; poll only when set)
- **Fix**: `useYorkieDoc` options/return signature

## Verification
- All signatures verified against `yorkie-js-sdk/packages/{sdk,react}` source
- `npm run lint` ✅ · `npm run build` ✅
- Rendered locally and spot-checked both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated JavaScript SDK docs for `Client.deactivate()` with optional `keepalive` and `synchronous`, including a `beforeunload` example and clarified unload-deactivation defaults/opt-out.
  * Expanded `Document` constructor docs with `disableGC`, `disablePresence`, and `enableDevtools`.
  * Updated channel attachment docs so `channelHeartbeatInterval` falls back to the client default for both realtime and polling, with examples.
  * Refreshed React SDK docs with provider controls (`activate`, `deactivateOnUnload`, `syncMode`, `documentPollInterval`, `channelHeartbeatInterval`) and new/updated hooks (`useYorkie`, `useRemoveDocument`, `detach`, `refetch`, `useDocument`/`useYorkieDoc` return values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->