### PR TITLE
Fix example detail page sidebar highlighting multiple files at once

### DIFF
--- a/utils/exampleFileUtils.ts
+++ b/utils/exampleFileUtils.ts
@@ -97,20 +97,16 @@ export const setFileOpen = (directoryInfo: DirectoryInfo, targetFilePath: string
 };
 
 const findOpenedFileInfo = (directoryInfo: DirectoryInfo, targetFilePath: string): FileInfo | null => {
-  let opendFileInfo: FileInfo | null = null;
+  let openedFileInfo: FileInfo | null = null;
   for (const child of directoryInfo.children) {
-    if (opendFileInfo != null) {
-      break;
-    }
     if (child.isFile) {
       child.isOpen = child.path === targetFilePath;
       if (child.isOpen) {
-        opendFileInfo = child;
-        break;
+        openedFileInfo = child;
       }
     } else {
-      opendFileInfo = opendFileInfo ?? findOpenedFileInfo(child, targetFilePath);
+      openedFileInfo = findOpenedFileInfo(child, targetFilePath) ?? openedFileInfo;
     }
   }
-  return opendFileInfo;
-}
+  return openedFileInfo;
+};


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fixes the code sidebar on example detail pages highlighting more than one
file at the same time.

`findOpenedFileInfo()` stopped traversing as soon as it found the clicked
file, but `isOpen` is only cleared on the nodes the loop actually visits.
Files positioned after the match kept their previous `isOpen` value, so
clicking a file above the current one left the old selection highlighted.
Clicking downward happened to work because the loop passed the previous
selection before reaching the break.

This removes the early exits so the whole tree is normalized in a single
pass, and keeps an already-found match from being overwritten by the null
a later subtree returns.

https://github.com/user-attachments/assets/dbf1a23c-5a92-4f1b-b543-afe884423589

And also renames the `opendFileInfo` typo to `openedFileInfo`

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #328 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opened-file detection to consistently evaluate all relevant entries.
  * Updated results now reflect the correct file when multiple opened files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->